### PR TITLE
fix(bicom): return combined error from ClearVoicemailForGuest

### DIFF
--- a/internal/bicom/client.go
+++ b/internal/bicom/client.go
@@ -416,20 +416,55 @@ func (c *Client) ResetVoicemailGreeting(ctx context.Context, extensionID string)
 	return c.SetVoicemailGreeting(ctx, extensionID, GreetingDefault)
 }
 
+// VoicemailClearError captures partial failures in ClearVoicemailForGuest.
+// Callers can use errors.As to extract granular failure details.
+type VoicemailClearError struct {
+	DeleteFailed   bool
+	GreetingFailed bool
+	DeleteErr      error
+	GreetingErr    error
+}
+
+func (e *VoicemailClearError) Error() string {
+	var parts []string
+	if e.DeleteFailed {
+		parts = append(parts, "voicemail delete failed")
+	}
+	if e.GreetingFailed {
+		parts = append(parts, "greeting reset failed")
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (e *VoicemailClearError) Is(target error) bool {
+	_, ok := target.(*VoicemailClearError)
+	return ok
+}
+
 // ClearVoicemailForGuest performs all voicemail cleanup for guest checkout:
 // - Deletes all messages
 // - Resets greeting to default
+// Returns VoicemailClearError if any step fails so callers can distinguish
+// partial from complete failures.
 func (c *Client) ClearVoicemailForGuest(ctx context.Context, extensionID string) error {
+	var clearErr VoicemailClearError
+
 	// Delete all messages first
 	if err := c.DeleteAllVoicemails(ctx, extensionID); err != nil {
 		log.Error().Err(err).Str("extension", extensionID).Msg("Failed to delete voicemails")
-		// Continue to reset greeting even if delete fails
+		clearErr.DeleteFailed = true
+		clearErr.DeleteErr = err
 	}
 
 	// Reset greeting to default
 	if err := c.ResetVoicemailGreeting(ctx, extensionID); err != nil {
 		log.Error().Err(err).Str("extension", extensionID).Msg("Failed to reset voicemail greeting")
-		return err
+		clearErr.GreetingFailed = true
+		clearErr.GreetingErr = err
+	}
+
+	if clearErr.DeleteFailed || clearErr.GreetingFailed {
+		return &clearErr
 	}
 
 	log.Info().

--- a/internal/bicom/client_test.go
+++ b/internal/bicom/client_test.go
@@ -3,6 +3,7 @@ package bicom
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -192,4 +193,94 @@ func TestListExtensions(t *testing.T) {
 	if len(exts) != 2 {
 		t.Errorf("expected 2 extensions, got %d", len(exts))
 	}
+}
+
+func TestClearVoicemailForGuest(t *testing.T) {
+	t.Run("both steps succeed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(APIResponse{Success: true})
+		}))
+		defer server.Close()
+
+		client, _ := NewClient(Config{
+			BaseURL: server.URL,
+			APIKey:  "test-key",
+		})
+
+		err := client.ClearVoicemailForGuest(context.Background(), "1001")
+		if err != nil {
+			t.Errorf("ClearVoicemailForGuest() error = %v", err)
+		}
+	})
+
+	t.Run("delete fails, greeting succeeds returns VoicemailClearError", func(t *testing.T) {
+		deleteFailed := true
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if r.FormValue("action") == "pbxware.vm.delete_all" && deleteFailed {
+				deleteFailed = false // reset for potential future calls
+				json.NewEncoder(w).Encode(APIResponse{Success: false, Message: "delete failed"})
+				return
+			}
+			json.NewEncoder(w).Encode(APIResponse{Success: true})
+		}))
+		defer server.Close()
+
+		client, _ := NewClient(Config{
+			BaseURL: server.URL,
+			APIKey:  "test-key",
+		})
+
+		err := client.ClearVoicemailForGuest(context.Background(), "1001")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var clearErr *VoicemailClearError
+		if !errors.As(err, &clearErr) {
+			t.Fatalf("expected VoicemailClearError, got %T", err)
+		}
+		if !clearErr.DeleteFailed {
+			t.Error("expected DeleteFailed to be true")
+		}
+		if clearErr.GreetingFailed {
+			t.Error("expected GreetingFailed to be false")
+		}
+	})
+
+	t.Run("both steps fail returns combined error", func(t *testing.T) {
+		deleteFailed := true
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if r.FormValue("action") == "pbxware.vm.delete_all" && deleteFailed {
+				deleteFailed = false
+				json.NewEncoder(w).Encode(APIResponse{Success: false, Message: "delete failed"})
+				return
+			}
+			json.NewEncoder(w).Encode(APIResponse{Success: false, Message: "greeting failed"})
+		}))
+		defer server.Close()
+
+		client, _ := NewClient(Config{
+			BaseURL: server.URL,
+			APIKey:  "test-key",
+		})
+
+		err := client.ClearVoicemailForGuest(context.Background(), "1001")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		var clearErr *VoicemailClearError
+		if !errors.As(err, &clearErr) {
+			t.Fatalf("expected VoicemailClearError, got %T", err)
+		}
+		if !clearErr.DeleteFailed {
+			t.Error("expected DeleteFailed to be true")
+		}
+		if !clearErr.GreetingFailed {
+			t.Error("expected GreetingFailed to be true")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

`ClearVoicemailForGuest` now returns a `*VoicemailClearError` whenever any step (voicemail delete or greeting reset) fails, instead of silently returning `nil` after logging a delete failure.

Callers can use `errors.As` to inspect granular failure details:

```go
err := provider.ClearVoicemailForGuest(ctx, "1001")
if err != nil {
    var clearErr *bicom.VoicemailClearError
    if errors.As(err, &clearErr) {
        if clearErr.DeleteFailed {
            // handle partial failure
        }
    }
}
```

## Changes

- **New `VoicemailClearError` struct** with `DeleteFailed`, `GreetingFailed`, `DeleteErr`, and `GreetingErr` fields
- **`ClearVoicemailForGuest`**: both steps are always attempted; a combined error is returned if any fail
- **`VoicemailClearError` implements `error`, `Is`**, making it compatible with `errors.As` / `errors.Is`
- **`TestClearVoicemailForGuest`**: three sub-tests for success, partial failure, and combined failure

Closes #TOP-9
