### PR TITLE
fix: add explicit Zultys import to prevent linker elimination

### DIFF
--- a/internal/tenant/manager.go
+++ b/internal/tenant/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sagostin/pbx-hospitality/internal/metrics"
 	"github.com/sagostin/pbx-hospitality/internal/pbx"
 	_ "github.com/sagostin/pbx-hospitality/internal/pbx/bicom" // Register Bicom provider
+	_ "github.com/sagostin/pbx-hospitality/internal/pbx/zultys" // Register Zultys provider
 	"github.com/sagostin/pbx-hospitality/internal/pms"
 )
 


### PR DESCRIPTION
## Summary

Zultys relies on `init()` self-registration with no explicit import in `main.go` or `tenant/manager.go`. Go's dead code elimination could theoretically drop the package since nothing directly references it.

This adds an explicit blank import alongside the existing bicom import:

```go
_ "github.com/sagostin/pbx-hospitality/internal/pbx/bicom" // Register Bicom provider
_ "github.com/sagostin/pbx-hospitality/internal/pbx/zultys" // Register Zultys provider
```

## Fix

Fixes [TOP-10](mention://issue/f1238ba2-9de7-4a8e-8518-92fcb0893a0a)
