### PR TITLE
pms/mitel: capture GuestName on NAM events via pending name tracking

### DIFF
--- a/internal/pms/mitel/mitel.go
+++ b/internal/pms/mitel/mitel.go
@@ -46,15 +46,17 @@ type Adapter struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
-	connected bool
+	connected   bool
+	pendingName map[string]string // room -> "" (pending), populated by next message
 }
 
 // NewAdapter creates a new Mitel protocol adapter
 func NewAdapter(host string, port int, opts ...pms.AdapterOption) (pms.Adapter, error) {
 	a := &Adapter{
-		host:   host,
-		port:   port,
-		events: make(chan pms.Event, 100),
+		host:        host,
+		port:        port,
+		events:      make(chan pms.Event, 100),
+		pendingName: make(map[string]string),
 	}
 
 	for _, opt := range opts {
@@ -214,7 +216,7 @@ func (a *Adapter) readLoop(ctx context.Context) {
 		}
 
 		// Parse the message
-		evt, err := parseMessage(msg)
+		evt, err := parseMessage(msg, a.pendingName)
 		if err != nil {
 			log.Error().Err(err).Bytes("raw", msg).Msg("Failed to parse Mitel message")
 			a.SendNak()
@@ -232,10 +234,37 @@ func (a *Adapter) readLoop(ctx context.Context) {
 	}
 }
 
-// parseMessage parses a Mitel PMS message
+// parseMessage parses a Mitel PMS message.
+// It accepts an optional pendingName map for stateful NAM guest-name tracking.
+// If pendingName is non-nil, NAM events use it to store/retrieve pending name data.
 // Format: <FUNC><STATUS><ROOM#> (10 chars total)
 // FUNC: 3 chars, STATUS: 2 chars, ROOM: 5 chars
-func parseMessage(msg []byte) (pms.Event, error) {
+// A name payload may arrive as a separate message longer than 10 chars,
+// with the 5-char room number at the start followed by the guest name.
+func parseMessage(msg []byte, pendingName map[string]string) (pms.Event, error) {
+	// Handle variable-length name payload: starts with 5-char room number
+	// followed by the guest name (e.g., "2129 Smith, John    ").
+	// Only used when there's a pending room waiting for a name.
+	if len(msg) > 10 && pendingName != nil {
+		payloadRoom := strings.TrimSpace(string(msg[0:5]))
+		if _, ok := pendingName[payloadRoom]; ok {
+			name := strings.TrimSpace(string(msg[5:]))
+			delete(pendingName, payloadRoom)
+			return pms.Event{
+				Type:      pms.EventNameUpdate,
+				Room:      payloadRoom,
+				GuestName: name,
+				Status:    true,
+				Timestamp: time.Now(),
+				RawData:   msg,
+				Metadata: map[string]string{
+					"function": FuncName,
+					"status":   "1",
+				},
+			}, nil
+		}
+	}
+
 	if len(msg) < 10 {
 		return pms.Event{}, fmt.Errorf("message too short: %d bytes", len(msg))
 	}
@@ -271,9 +300,19 @@ func parseMessage(msg []byte) (pms.Event, error) {
 
 	case FuncName:
 		evt.Type = pms.EventNameUpdate
-		// Name data follows in subsequent message or field
-		// For now, set status
 		evt.Status = status == "1"
+		// Mitel SX-200 sends NAM followed by a name payload message.
+		// Register room as pending; if pendingName already has a value for this
+		// room, consume it as the guest name (name payload arrived first).
+		if pendingName != nil {
+			if name, ok := pendingName[room]; ok && name != "" {
+				evt.GuestName = name
+				delete(pendingName, room)
+			} else {
+				// Mark as pending; next message for this room carries the name.
+				pendingName[room] = ""
+			}
+		}
 
 	case FuncRoom:
 		evt.Type = pms.EventRoomStatus
@@ -292,5 +331,5 @@ func parseMessage(msg []byte) (pms.Event, error) {
 
 // ParseMessage is exported for testing
 func ParseMessage(msg []byte) (pms.Event, error) {
-	return parseMessage(msg)
+	return parseMessage(msg, nil)
 }

--- a/internal/pms/mitel/mitel_test.go
+++ b/internal/pms/mitel/mitel_test.go
@@ -115,7 +115,7 @@ func TestControlCharacters(t *testing.T) {
 		t.Errorf("ETX = 0x%02x, want 0x03", ETX)
 	}
 	if ENQ != 0x05 {
-		t.Errorf("ENQ = 0x%02x, want 0x05", ENQ)
+		t.Errorf("ENQ = 0x%05x, want 0x05", ENQ)
 	}
 	if ACK != 0x06 {
 		t.Errorf("ACK = 0x%02x, want 0x06", ACK)
@@ -123,4 +123,92 @@ func TestControlCharacters(t *testing.T) {
 	if NAK != 0x15 {
 		t.Errorf("NAK = 0x%02x, want 0x15", NAK)
 	}
+}
+
+func TestParseMessageWithGuestName(t *testing.T) {
+	t.Run("NAM with pending name populates GuestName", func(t *testing.T) {
+		pending := map[string]string{"2129": "John Smith"}
+		evt, err := parseMessage([]byte("NAM1  2129"), pending)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if evt.Type != pms.EventNameUpdate {
+			t.Errorf("event type = %v, want %v", evt.Type, pms.EventNameUpdate)
+		}
+		if evt.Room != "2129" {
+			t.Errorf("room = %q, want %q", evt.Room, "2129")
+		}
+		if evt.GuestName != "John Smith" {
+			t.Errorf("guest name = %q, want %q", evt.GuestName, "John Smith")
+		}
+		if evt.Status != true {
+			t.Errorf("status = %v, want true", evt.Status)
+		}
+		// Pending entry should be consumed
+		if _, ok := pending["2129"]; ok {
+			t.Errorf("pending entry for room 2129 was not cleared")
+		}
+	})
+
+	t.Run("NAM without prior pending name registers as pending", func(t *testing.T) {
+		pending := map[string]string{}
+		evt, err := parseMessage([]byte("NAM1  2129"), pending)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if evt.Type != pms.EventNameUpdate {
+			t.Errorf("event type = %v, want %v", evt.Type, pms.EventNameUpdate)
+		}
+		if evt.GuestName != "" {
+			t.Errorf("guest name = %q, want empty string (pending)", evt.GuestName)
+		}
+		// Pending entry should be registered
+		if _, ok := pending["2129"]; !ok {
+			t.Errorf("pending entry for room 2129 was not registered")
+		}
+	})
+
+	t.Run("NAM with nil pendingName leaves GuestName empty", func(t *testing.T) {
+		evt, err := parseMessage([]byte("NAM1  2129"), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if evt.GuestName != "" {
+			t.Errorf("guest name = %q, want empty string", evt.GuestName)
+		}
+	})
+
+	t.Run("name payload message with pending room populates GuestName", func(t *testing.T) {
+		// Room 2129 is waiting for a name; name payload arrives
+		pending := map[string]string{"2129": ""}
+		evt, err := parseMessage([]byte("2129 John Smith      "), pending)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if evt.Type != pms.EventNameUpdate {
+			t.Errorf("event type = %v, want %v", evt.Type, pms.EventNameUpdate)
+		}
+		if evt.Room != "2129" {
+			t.Errorf("room = %q, want %q", evt.Room, "2129")
+		}
+		if evt.GuestName != "John Smith" {
+			t.Errorf("guest name = %q, want %q", evt.GuestName, "John Smith")
+		}
+		if evt.Status != true {
+			t.Errorf("status = %v, want true", evt.Status)
+		}
+		// Pending entry should be consumed
+		if _, ok := pending["2129"]; ok {
+			t.Errorf("pending entry for room 2129 was not cleared")
+		}
+	})
+
+	t.Run("name payload without pending room returns error", func(t *testing.T) {
+		// No pending room; name payload parsed as generic message
+		pending := map[string]string{}
+		_, err := parseMessage([]byte("2129 John Smith      "), pending)
+		if err == nil {
+			t.Errorf("expected error for unrecognized format without pending room, got nil")
+		}
+	})
 }


### PR DESCRIPTION
Co-authored-by: multica-agent <github@multica.ai>
