### PR TITLE
feat: add Mitel PMS Listener TCP server

### DIFF
--- a/internal/pms/listener/mitel_server.go
+++ b/internal/pms/listener/mitel_server.go
@@ -1,0 +1,303 @@
+package listener
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/sagostin/pbx-hospitality/internal/pms"
+	"github.com/sagostin/pbx-hospitality/internal/pms/mitel"
+)
+
+const (
+	// DefaultPort is the default TCP listen port for Mitel PMS connections
+	DefaultPort = 23
+
+	// ACKTimeout is the maximum time to send ACK response (< 100ms SLA)
+	ACKTimeout = 100 * time.Millisecond
+
+	// ConnectionTimeout is how long to wait for activity before closing idle connection
+	ConnectionTimeout = 5 * time.Minute
+
+	// MaxMessageSize is the maximum size of a single PMS message
+	MaxMessageSize = 256
+)
+
+// Listener implements a TCP server that listens for incoming Mitel PMS connections.
+// Each connection is handled independently, parsing STX/ETX framed messages and
+// converting them to PMS events for downstream processing.
+type Listener struct {
+	host    string
+	port    int
+	events  chan pms.Event
+	listener net.Listener
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	mu     sync.RWMutex
+	closed  bool
+}
+
+// NewListener creates a new PMS Listener TCP server.
+func NewListener(host string, port int) *Listener {
+	return &Listener{
+		host:   host,
+		port:   port,
+		events: make(chan pms.Event, 100),
+	}
+}
+
+// Events returns the channel of parsed PMS events from all connections.
+func (l *Listener) Events() <-chan pms.Event {
+	return l.events
+}
+
+// Listen starts the TCP server and accepts incoming connections.
+// It blocks until the context is cancelled or an error occurs.
+func (l *Listener) Listen(ctx context.Context) error {
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return fmt.Errorf("listener is closed")
+	}
+
+	addr := fmt.Sprintf("%s:%d", l.host, l.port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		l.mu.Unlock()
+		return fmt.Errorf("listen on %s: %w", addr, err)
+	}
+	l.listener = ln
+	l.closed = false
+	l.mu.Unlock()
+
+	ctx, l.cancel = context.WithCancel(ctx)
+
+	log.Info().
+		Str("host", l.host).
+		Int("port", l.port).
+		Msg("PMS Listener started")
+
+	// Accept loop
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Set accept deadline to allow periodic context checks
+		l.listener.(*net.TCPListener).SetDeadline(time.Now().Add(1 * time.Second))
+
+		conn, err := l.listener.Accept()
+		if err != nil {
+			if l.closed {
+				return nil
+			}
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				// Deadline hit, check context and continue
+				continue
+			}
+			log.Error().Err(err).Msg("Accept error on PMS Listener")
+			continue
+		}
+
+		// Handle each connection in a goroutine
+		l.wg.Add(1)
+		go func() {
+			defer l.wg.Done()
+			l.handleConnection(ctx, conn)
+		}()
+	}
+}
+
+// handleConnection processes a single PMS TCP connection.
+// It reads STX/ETX framed messages, sends ACK/NAK responses, and emits events.
+func (l *Listener) handleConnection(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+
+	remoteAddr := conn.RemoteAddr().String()
+	log.Info().
+		Str("remote", remoteAddr).
+		Msg("PMS connection opened")
+
+	// Set connection-level deadlines
+	conn.SetReadDeadline(time.Now().Add(ConnectionTimeout))
+	conn.SetWriteDeadline(time.Now().Add(ACKTimeout))
+
+	reader := bufio.NewReaderSize(conn, MaxMessageSize)
+
+	for {
+		// Check context before each read
+		select {
+		case <-ctx.Done():
+			log.Debug().Str("remote", remoteAddr).Msg("Connection closed: context cancelled")
+			return
+		default:
+		}
+
+		// Extend deadline on each successful operation
+		conn.SetReadDeadline(time.Now().Add(ConnectionTimeout))
+
+		// Read until STX or ENQ
+		b, err := reader.ReadByte()
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				log.Debug().Str("remote", remoteAddr).Msg("Connection closed: idle timeout")
+			} else {
+				log.Debug().Err(err).Str("remote", remoteAddr).Msg("Connection closed: read error")
+			}
+			return
+		}
+
+		// Handle ENQ (polling) - respond with ACK immediately
+		if b == mitel.ENQ {
+			conn.SetWriteDeadline(time.Now().Add(ACKTimeout))
+			if _, err := conn.Write([]byte{mitel.ACK}); err != nil {
+				log.Warn().Err(err).Str("remote", remoteAddr).Msg("Failed to send ACK for ENQ")
+				return
+			}
+			// Extend deadline after successful ACK
+			conn.SetReadDeadline(time.Now().Add(ConnectionTimeout))
+			continue
+		}
+
+		// Expect STX (start of message)
+		if b != mitel.STX {
+			// Not STX, skip and continue looking
+			continue
+		}
+
+		// Read message body until ETX
+		var msg []byte
+		for {
+			b, err := reader.ReadByte()
+			if err != nil {
+				log.Warn().Err(err).Str("remote", remoteAddr).Msg("Error reading message body")
+				return
+			}
+			if b == mitel.ETX {
+				break
+			}
+			if len(msg) >= MaxMessageSize {
+				log.Warn().
+					Str("remote", remoteAddr).
+					Int("size", len(msg)).
+					Msg("Message exceeds max size, aborting")
+				return
+			}
+			msg = append(msg, b)
+		}
+
+		if len(msg) == 0 {
+			// Empty message, send NAK
+			l.sendResponse(conn, mitel.NAK, remoteAddr)
+			continue
+		}
+
+		// Parse the message using the mitel package parser
+		evt, err := mitel.ParseMessage(msg)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("remote", remoteAddr).
+				Bytes("raw", msg).
+				Msg("Failed to parse Mitel message")
+			l.sendResponse(conn, mitel.NAK, remoteAddr)
+			continue
+		}
+
+		// Send ACK before processing (meets < 100ms SLA)
+		if !l.sendResponse(conn, mitel.ACK, remoteAddr) {
+			return
+		}
+
+		// Extend read deadline after successful ACK
+		conn.SetReadDeadline(time.Now().Add(ConnectionTimeout))
+
+		// Send event to channel
+		select {
+		case l.events <- evt:
+			log.Debug().
+				Str("remote", remoteAddr).
+				Str("event", evt.Type.String()).
+				Str("room", evt.Room).
+				Msg("PMS event emitted")
+		case <-ctx.Done():
+			return
+		default:
+			log.Warn().
+				Str("remote", remoteAddr).
+				Msg("Event channel full, dropping event")
+		}
+	}
+}
+
+// sendResponse sends an ACK or NAK response to the PMS.
+// Returns false if the write fails (connection should be closed).
+func (l *Listener) sendResponse(conn net.Conn, response byte, remoteAddr string) bool {
+	conn.SetWriteDeadline(time.Now().Add(ACKTimeout))
+	if _, err := conn.Write([]byte{response}); err != nil {
+		log.Warn().
+			Err(err).
+			Str("remote", remoteAddr).
+			Msg("Failed to send response")
+		return false
+	}
+	return true
+}
+
+// Close stops the listener and closes all active connections.
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.closed {
+		return nil
+	}
+
+	l.closed = true
+
+	if l.cancel != nil {
+		l.cancel()
+	}
+
+	if l.listener != nil {
+		l.listener.Close()
+	}
+
+	// Wait for connection handlers
+	l.wg.Wait()
+
+	close(l.events)
+
+	log.Info().
+		Str("host", l.host).
+		Int("port", l.port).
+		Msg("PMS Listener stopped")
+
+	return nil
+}
+
+// Host returns the listen address.
+func (l *Listener) Host() string {
+	return l.host
+}
+
+// Port returns the listen port.
+func (l *Listener) Port() int {
+	return l.port
+}
+
+// ParseMessage is a convenience wrapper for testing.
+// Parses a raw message payload (between STX and ETX).
+func ParseMessage(msg []byte) (pms.Event, error) {
+	// Validate and strip whitespace
+	msgStr := strings.TrimSpace(string(msg))
+	return mitel.ParseMessage([]byte(msgStr))
+}

--- a/internal/pms/listener/mitel_server_test.go
+++ b/internal/pms/listener/mitel_server_test.go
@@ -1,0 +1,357 @@
+package listener
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sagostin/pbx-hospitality/internal/pms"
+)
+
+func TestListenerDefaults(t *testing.T) {
+	l := NewListener("localhost", DefaultPort)
+	if l.Host() != "localhost" {
+		t.Errorf("Host() = %q, want %q", l.Host(), "localhost")
+	}
+	if l.Port() != DefaultPort {
+		t.Errorf("Port() = %d, want %d", l.Port(), DefaultPort)
+	}
+}
+
+func TestParseMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    pms.EventType
+		room    string
+		status  bool
+		wantErr bool
+	}{
+		{
+			name:   "check-in room 2129",
+			input:  "CHK1  2129",
+			want:   pms.EventCheckIn,
+			room:   "2129",
+			status: true,
+		},
+		{
+			name:   "check-out room 2129",
+			input:  "CHK0  2129",
+			want:   pms.EventCheckOut,
+			room:   "2129",
+			status: false,
+		},
+		{
+			name:   "message waiting ON for room 101",
+			input:  "MW 1   101",
+			want:   pms.EventMessageWaiting,
+			room:   "101",
+			status: true,
+		},
+		{
+			name:   "message waiting OFF for room 101",
+			input:  "MW 0   101",
+			want:   pms.EventMessageWaiting,
+			room:   "101",
+			status: false,
+		},
+		{
+			name:   "DND on for room 500",
+			input:  "DND1   500",
+			want:   pms.EventDND,
+			room:   "500",
+			status: true,
+		},
+		{
+			name:   "room status occupied",
+			input:  "RM 1  1015",
+			want:   pms.EventRoomStatus,
+			room:   "1015",
+			status: true,
+		},
+		{
+			name:   "name update for room 2129",
+			input:  "NAM1  2129",
+			want:   pms.EventNameUpdate,
+			room:   "2129",
+			status: true,
+		},
+		{
+			name:    "message too short",
+			input:   "CHK1",
+			wantErr: true,
+		},
+		{
+			name:    "unknown function code",
+			input:   "XXX1 2129",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evt, err := ParseMessage([]byte(tt.input))
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if evt.Type != tt.want {
+				t.Errorf("event type = %v, want %v", evt.Type, tt.want)
+			}
+
+			if evt.Room != tt.room {
+				t.Errorf("room = %q, want %q", evt.Room, tt.room)
+			}
+
+			if evt.Status != tt.status {
+				t.Errorf("status = %v, want %v", evt.Status, tt.status)
+			}
+		})
+	}
+}
+
+// buildMitelMessage builds a complete Mitel message with STX/ETX framing
+func buildMitelMessage(payload string) []byte {
+	msg := make([]byte, 0, len(payload)+2)
+	msg = append(msg, STX)
+	msg = append(msg, payload...)
+	msg = append(msg, ETX)
+	return msg
+}
+
+// STX, ETX, ENQ, ACK, NAK are control characters used in Mitel protocol
+const (
+	STX = 0x02
+	ETX = 0x03
+	ENQ = 0x05
+	ACK = 0x06
+	NAK = 0x15
+)
+
+func TestListenerIntegration(t *testing.T) {
+	// Start listener on random port
+	ln := NewListener("localhost", 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start listener in background
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ln.Listen(ctx)
+	}()
+
+	// Give listener time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Get actual port
+	ln.mu.RLock()
+	addr := ln.listener.Addr().String()
+	ln.mu.RUnlock()
+
+	// Connect to listener
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Failed to connect to listener: %v", err)
+	}
+	defer conn.Close()
+
+	// Test ENQ handling
+	_, err = conn.Write([]byte{ENQ})
+	if err != nil {
+		t.Fatalf("Failed to send ENQ: %v", err)
+	}
+
+	// Read ACK response
+	conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+	resp := make([]byte, 1)
+	n, err := conn.Read(resp)
+	if err != nil {
+		t.Fatalf("Failed to read ACK: %v", err)
+	}
+	if n != 1 || resp[0] != ACK {
+		t.Errorf("Expected ACK (0x06), got 0x%02x", resp[0])
+	}
+
+	// Send a check-in message: <STX>CHK1  2129<ETX>
+	payload := "CHK1  2129"
+	msg := buildMitelMessage(payload)
+
+	_, err = conn.Write(msg)
+	if err != nil {
+		t.Fatalf("Failed to send message: %v", err)
+	}
+
+	// Read ACK response
+	conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+	n, err = conn.Read(resp)
+	if err != nil {
+		t.Fatalf("Failed to read ACK: %v", err)
+	}
+	if n != 1 || resp[0] != ACK {
+		t.Errorf("Expected ACK (0x06), got 0x%02x", resp[0])
+	}
+
+	// Wait for event
+	select {
+	case evt := <-ln.Events():
+		if evt.Type != pms.EventCheckIn {
+			t.Errorf("Event type = %v, want %v", evt.Type, pms.EventCheckIn)
+		}
+		if evt.Room != "2129" {
+			t.Errorf("Room = %q, want %q", evt.Room, "2129")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for event")
+	}
+
+	// Send a NAK case (message too short)
+	shortMsg := []byte{STX, 'C', 'H', 'K', ETX}
+	_, err = conn.Write(shortMsg)
+	if err != nil {
+		t.Fatalf("Failed to send short message: %v", err)
+	}
+
+	// Read NAK response
+	conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+	n, err = conn.Read(resp)
+	if err != nil {
+		t.Fatalf("Failed to read NAK: %v", err)
+	}
+	if n != 1 || resp[0] != NAK {
+		t.Errorf("Expected NAK (0x15), got 0x%02x", resp[0])
+	}
+
+	// Cancel context to stop listener
+	cancel()
+
+	// Wait for listener to stop
+	select {
+	case <-errCh:
+		// Expected
+	case <-time.After(2 * time.Second):
+		t.Error("Listener did not stop in time")
+	}
+}
+
+func TestListenerClose(t *testing.T) {
+	l := NewListener("localhost", 0)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start listener
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- l.Listen(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Close listener
+	if err := l.Close(); err != nil {
+		t.Errorf("Close() returned error: %v", err)
+	}
+
+	cancel()
+
+	select {
+	case <-errCh:
+		// Expected
+	case <-time.After(2 * time.Second):
+		t.Error("Listener did not stop")
+	}
+
+	// Double close should be safe
+	if err := l.Close(); err != nil {
+		t.Errorf("Second Close() returned error: %v", err)
+	}
+}
+
+func TestListenerConcurrentConnections(t *testing.T) {
+	l := NewListener("localhost", 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- l.Listen(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	lnAddr := l.listener.Addr().String()
+
+	// Open multiple connections concurrently
+	const numConns = 3
+	var wg sync.WaitGroup
+	errChan := make(chan error, numConns)
+
+	for i := 0; i < numConns; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			conn, err := net.Dial("tcp", lnAddr)
+			if err != nil {
+				errChan <- fmt.Errorf("dial: %w", err)
+				return
+			}
+			defer conn.Close()
+
+			// Send a message
+			msg := buildMitelMessage(fmt.Sprintf("CHK1  %04d", idx))
+			if _, err := conn.Write(msg); err != nil {
+				errChan <- fmt.Errorf("write: %w", err)
+				return
+			}
+
+			// Read ACK
+			conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+			resp := make([]byte, 1)
+			if _, err := conn.Read(resp); err != nil {
+				errChan <- fmt.Errorf("read: %w", err)
+				return
+			}
+			if resp[0] != ACK {
+				errChan <- fmt.Errorf("expected ACK, got 0x%02x", resp[0])
+				return
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	// Check for errors
+	for err := range errChan {
+		t.Errorf("Connection error: %v", err)
+	}
+
+	// Collect events
+	eventsReceived := 0
+	for i := 0; i < numConns; i++ {
+		select {
+		case <-l.Events():
+			eventsReceived++
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Timed out waiting for events, got %d of %d", eventsReceived, numConns)
+		}
+	}
+
+	if eventsReceived != numConns {
+		t.Errorf("Received %d events, want %d", eventsReceived, numConns)
+	}
+
+	cancel()
+	<-errCh
+}


### PR DESCRIPTION
## Summary

Implements a TCP server for incoming Mitel SX-200 PMS connections (TOP-12).

### What
-  — Listener struct with configurable host:port (default 23)
-  — Unit and integration tests

### Features
- TCP server binds to configured host:port
- Parses STX (0x02) / ETX (0x03) framed messages
- ENQ polling with immediate ACK (< 100ms SLA)
- ACK on valid message, NAK on parse failure
- Concurrent connections with idle timeout
- Emits structured  to channel for downstream processing

### Tests
- TestListenerDefaults, TestParseMessage, TestListenerIntegration, TestListenerClose, TestListenerConcurrentConnections

Closes TOP-12