### PR TITLE
feat(bicom): implement extension provisioning (add/delete)

### DIFF
--- a/internal/bicom/client.go
+++ b/internal/bicom/client.go
@@ -260,6 +260,57 @@ func (c *Client) UpdateServicePlan(ctx context.Context, extensionID, servicePlan
 	return nil
 }
 
+// AddExtension creates a new extension for the tenant.
+// This is used for dynamic room provisioning where extensions are created
+// on check-in and removed on check-out rather than pre-provisioned.
+// Required params: name, ext (extension number), prot (protocol, e.g. "sip").
+// Optional: email, secret, pin, voicemail, status, incominglimit, outgoinglimit,
+// service_plan, and other PBXware extension attributes.
+func (c *Client) AddExtension(ctx context.Context, params map[string]string) (*Extension, error) {
+	resp, err := c.doPost(ctx, "pbxware.ext.add", params)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.Success {
+		return nil, fmt.Errorf("failed to add extension: %s", resp.Message)
+	}
+
+	var ext Extension
+	if err := json.Unmarshal(resp.Data, &ext); err != nil {
+		// API may return just an ID or a full Extension object
+		return nil, fmt.Errorf("parsing added extension: %w", err)
+	}
+
+	log.Info().
+		Str("extension", ext.Extension).
+		Str("name", ext.Name).
+		Msg("Extension created")
+
+	return &ext, nil
+}
+
+// DeleteExtension removes an extension from the tenant.
+// The extensionID is the PBXware internal ID (not the dialed extension number).
+func (c *Client) DeleteExtension(ctx context.Context, extensionID string) error {
+	resp, err := c.doPost(ctx, "pbxware.ext.delete", map[string]string{
+		"id": extensionID,
+	})
+	if err != nil {
+		return err
+	}
+
+	if !resp.Success {
+		return fmt.Errorf("failed to delete extension: %s", resp.Message)
+	}
+
+	log.Info().
+		Str("extension", extensionID).
+		Msg("Extension deleted")
+
+	return nil
+}
+
 // =============================================================================
 // Wake-Up Call Management
 // =============================================================================

--- a/internal/bicom/client_test.go
+++ b/internal/bicom/client_test.go
@@ -284,3 +284,124 @@ func TestClearVoicemailForGuest(t *testing.T) {
 		}
 	})
 }
+
+func TestAddExtension(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.FormValue("action") != "pbxware.ext.add" {
+			t.Errorf("unexpected action: %s", r.FormValue("action"))
+		}
+		if r.FormValue("name") != "Room 101" {
+			t.Errorf("unexpected name: %s", r.FormValue("name"))
+		}
+		if r.FormValue("ext") != "1001" {
+			t.Errorf("unexpected ext: %s", r.FormValue("ext"))
+		}
+		if r.FormValue("prot") != "sip" {
+			t.Errorf("unexpected prot: %s", r.FormValue("prot"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(APIResponse{
+			Success: true,
+			Data:    json.RawMessage(`{"id": "5", "extension": "1001", "name": "Room 101"}`),
+		})
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(Config{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+	})
+
+	ext, err := client.AddExtension(context.Background(), map[string]string{
+		"name": "Room 101",
+		"ext":  "1001",
+		"prot": "sip",
+	})
+	if err != nil {
+		t.Errorf("AddExtension() error = %v", err)
+	}
+	if ext == nil {
+		t.Fatal("expected extension, got nil")
+	}
+	if ext.ID != "5" {
+		t.Errorf("expected ID=5, got %s", ext.ID)
+	}
+	if ext.Extension != "1001" {
+		t.Errorf("expected Extension=1001, got %s", ext.Extension)
+	}
+}
+
+func TestAddExtensionFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(APIResponse{
+			Success: false,
+			Message: "extension number already exists",
+		})
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(Config{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+	})
+
+	_, err := client.AddExtension(context.Background(), map[string]string{
+		"name": "Room 101",
+		"ext":  "1001",
+		"prot": "sip",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestDeleteExtension(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.FormValue("action") != "pbxware.ext.delete" {
+			t.Errorf("unexpected action: %s", r.FormValue("action"))
+		}
+		if r.FormValue("id") != "5" {
+			t.Errorf("unexpected id: %s", r.FormValue("id"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(APIResponse{
+			Success: true,
+			Message: "Extension deleted",
+		})
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(Config{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+	})
+
+	err := client.DeleteExtension(context.Background(), "5")
+	if err != nil {
+		t.Errorf("DeleteExtension() error = %v", err)
+	}
+}
+
+func TestDeleteExtensionFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(APIResponse{
+			Success: false,
+			Message: "extension not found",
+		})
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(Config{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+	})
+
+	err := client.DeleteExtension(context.Background(), "999")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
Implement extension provisioning via Bicom REST API for dynamic room provisioning.

## Changes
- Add `AddExtension(ctx, params)` - calls pbxware.ext.add via POST
- Add `DeleteExtension(ctx, extensionID)` - calls pbxware.ext.delete via POST
- Add unit tests for both new methods