### PR TITLE
feat: Mitel adapter socket-binding mode integration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,14 @@ type PMSConfig struct {
 	PathPrefix string `yaml:"path_prefix,omitempty"`
 	// AuthToken is the bearer token for TigerTMS authentication
 	AuthToken string `yaml:"auth_token,omitempty"`
+
+	// Socket-binding mode: the integration service binds a local TCP socket
+	// and the PMS connects to this socket. Use ListenHost/ListenPort instead
+	// of Host/Port. If AllowedPMSIPs is non-empty, only connections from
+	// these IPs will be accepted.
+	ListenHost      string   `yaml:"listen_host,omitempty"`
+	ListenPort      int      `yaml:"listen_port,omitempty"`
+	AllowedPMSIPs   []string `yaml:"allowed_pms_ips,omitempty"`
 }
 
 // PBXConfig holds PBX provider settings

--- a/internal/pms/listener/mitel_server.go
+++ b/internal/pms/listener/mitel_server.go
@@ -29,6 +29,10 @@ const (
 	MaxMessageSize = 256
 )
 
+func init() {
+	pms.RegisterListener("mitel", NewMitelListener)
+}
+
 // Listener implements a TCP server that listens for incoming Mitel PMS connections.
 // Each connection is handled independently, parsing STX/ETX framed messages and
 // converting them to PMS events for downstream processing.
@@ -36,6 +40,7 @@ type Listener struct {
 	host    string
 	port    int
 	events  chan pms.Event
+	allowed []string // allowed PMS IPs; if empty, all IPs are allowed
 	listener net.Listener
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
@@ -52,9 +57,36 @@ func NewListener(host string, port int) *Listener {
 	}
 }
 
+// NewMitelListener is the factory function registered with the PMS listener registry.
+func NewMitelListener(cfg pms.ListenerConfig, events chan pms.Event) (pms.Listener, error) {
+	l := &Listener{
+		host:    cfg.ListenHost,
+		port:    cfg.ListenPort,
+		events:  events,
+		allowed: cfg.AllowedPMSIPs,
+	}
+	if l.port == 0 {
+		l.port = DefaultPort
+	}
+	return l, nil
+}
+
 // Events returns the channel of parsed PMS events from all connections.
 func (l *Listener) Events() <-chan pms.Event {
 	return l.events
+}
+
+// isAllowed checks if the remote IP is allowed to connect.
+func (l *Listener) isAllowed(remoteIP string) bool {
+	if len(l.allowed) == 0 {
+		return true
+	}
+	for _, ip := range l.allowed {
+		if ip == remoteIP {
+			return true
+		}
+	}
+	return false
 }
 
 // Listen starts the TCP server and accepts incoming connections.
@@ -122,6 +154,18 @@ func (l *Listener) handleConnection(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 
 	remoteAddr := conn.RemoteAddr().String()
+	remoteIP, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		remoteIP = remoteAddr
+	}
+
+	// Check IP allowlist
+	if !l.isAllowed(remoteIP) {
+		log.Warn().Str("remote", remoteAddr).Msg("PMS connection rejected: IP not allowed")
+		conn.Close()
+		return
+	}
+
 	log.Info().
 		Str("remote", remoteAddr).
 		Msg("PMS connection opened")

--- a/internal/pms/listener/mitel_server_test.go
+++ b/internal/pms/listener/mitel_server_test.go
@@ -355,3 +355,120 @@ func TestListenerConcurrentConnections(t *testing.T) {
 	cancel()
 	<-errCh
 }
+
+func TestListenerIPAllowlist(t *testing.T) {
+	l := NewListener("localhost", 0)
+	l.allowed = []string{"127.0.0.1", "::1"} // Only allow localhost
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- l.Listen(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	lnAddr := l.listener.Addr().String()
+
+	// Allowed connection should succeed
+	t.Run("allowed IP connects successfully", func(t *testing.T) {
+		conn, err := net.Dial("tcp", lnAddr)
+		if err != nil {
+			t.Fatalf("Failed to connect: %v", err)
+		}
+		defer conn.Close()
+
+		msg := buildMitelMessage("CHK1  2129")
+		if _, err := conn.Write(msg); err != nil {
+			t.Fatalf("Failed to send message: %v", err)
+		}
+
+		conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+		resp := make([]byte, 1)
+		n, err := conn.Read(resp)
+		if err != nil {
+			t.Fatalf("Failed to read ACK: %v", err)
+		}
+		if n != 1 || resp[0] != ACK {
+			t.Errorf("Expected ACK, got 0x%02x", resp[0])
+		}
+	})
+
+	cancel()
+	<-errCh
+}
+
+func TestNewMitelListenerFactory(t *testing.T) {
+	events := make(chan pms.Event, 10)
+	cfg := pms.ListenerConfig{
+		ListenHost: "0.0.0.0",
+		ListenPort: 0, // Will use default
+		AllowedPMSIPs: []string{"192.168.1.100"},
+	}
+
+	l, err := NewMitelListener(cfg, events)
+	if err != nil {
+		t.Fatalf("NewMitelListener failed: %v", err)
+	}
+
+	if l.Host() != "0.0.0.0" {
+		t.Errorf("Host() = %q, want %q", l.Host(), "0.0.0.0")
+	}
+
+	// Port should default to DefaultPort when 0
+	if l.Port() != DefaultPort {
+		t.Errorf("Port() = %d, want %d (default)", l.Port(), DefaultPort)
+	}
+}
+
+func TestListenerAllowedIPs(t *testing.T) {
+	tests := []struct {
+		name     string
+		allowed  []string
+		ip       string
+		expected bool
+	}{
+		{
+			name:     "empty allowlist permits all",
+			allowed:  []string{},
+			ip:       "192.168.1.100",
+			expected: true,
+		},
+		{
+			name:     "nil allowlist permits all",
+			allowed:  nil,
+			ip:       "192.168.1.100",
+			expected: true,
+		},
+		{
+			name:     "matching IP is allowed",
+			allowed:  []string{"192.168.1.100", "10.0.0.1"},
+			ip:       "192.168.1.100",
+			expected: true,
+		},
+		{
+			name:     "non-matching IP is denied",
+			allowed:  []string{"192.168.1.100"},
+			ip:       "10.0.0.1",
+			expected: false,
+		},
+		{
+			name:     "localhost IPv4 is allowed when listed",
+			allowed:  []string{"127.0.0.1"},
+			ip:       "127.0.0.1",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewListener("localhost", 0)
+			l.allowed = tt.allowed
+			if got := l.isAllowed(tt.ip); got != tt.expected {
+				t.Errorf("isAllowed(%q) = %v, want %v", tt.ip, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/pms/protocol.go
+++ b/internal/pms/protocol.go
@@ -107,3 +107,48 @@ type ProtocolError struct {
 func (e *ProtocolError) Error() string {
 	return e.Protocol + ": " + e.Message
 }
+
+// ListenerConfig holds configuration for socket-binding mode
+type ListenerConfig struct {
+	ListenHost string
+	ListenPort int
+	AllowedPMSIPs []string // If non-empty, only connections from these IPs are allowed
+}
+
+// Listener is the interface for socket-binding PMS listeners
+type Listener interface {
+	// Listen starts the TCP server and returns a channel of PMS events
+	Listen(ctx context.Context) error
+
+	// Events returns the channel of parsed PMS events
+	Events() <-chan Event
+
+	// Close stops the listener
+	Close() error
+
+	// Host returns the listen address
+	Host() string
+
+	// Port returns the listen port
+	Port() int
+}
+
+// ListenerFactory creates a PMS listener from configuration
+type ListenerFactory func(cfg ListenerConfig, events chan Event) (Listener, error)
+
+// ListenerRegistry holds available protocol listeners
+var ListenerRegistry = make(map[string]ListenerFactory)
+
+// RegisterListener adds a protocol listener factory to the registry
+func RegisterListener(protocol string, factory ListenerFactory) {
+	ListenerRegistry[protocol] = factory
+}
+
+// NewListener creates a PMS listener based on protocol name
+func NewListener(protocol string, cfg ListenerConfig, events chan Event) (Listener, error) {
+	factory, ok := ListenerRegistry[protocol]
+	if !ok {
+		return nil, &ProtocolError{Protocol: protocol, Message: "unsupported protocol or listener not available"}
+	}
+	return factory(cfg, events)
+}


### PR DESCRIPTION
Integrates the existing Mitel PMS listener into the adapter registry with full socket-binding mode support per TOP-27/TOP-30.