### PR TITLE
feat(crypto): AES-256-GCM encryption layer for credentials at rest (TOP-19)

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -1,0 +1,184 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	// NonceSize is the size of a GCM nonce (12 bytes).
+	NonceSize = 12
+	// KeySize is the size of an AES-256 key (32 bytes).
+	KeySize = 32
+)
+
+var (
+	ErrInvalidKeySize    = errors.New("crypto: encryption master key must be 32 bytes (base64 encoded)")
+	ErrInvalidCiphertext = errors.New("crypto: ciphertext too short to be valid")
+	ErrDecryptionFailed  = errors.New("crypto: decryption failed (ciphertext tampered or wrong key)")
+)
+
+// EncryptedPayload holds a versioned ciphertext suitable for storage.
+type EncryptedPayload struct {
+	// Version tracks the key version / nonce derivation. 0 means "no versioning".
+	Version uint32 `json:"v"`
+	// Nonce is the GCM nonce used for this encryption (base64).
+	Nonce string `json:"n"`
+	// Ciphertext is the encrypted data (base64).
+	Ciphertext string `json:"c"`
+}
+
+// NewEncryptedPayload builds an EncryptedPayload from raw ciphertext and a version.
+func NewEncryptedPayload(version uint32, nonce, ciphertext []byte) EncryptedPayload {
+	return EncryptedPayload{
+		Version:    version,
+		Nonce:      base64.RawURLEncoding.EncodeToString(nonce),
+		Ciphertext: base64.RawURLEncoding.EncodeToString(ciphertext),
+	}
+}
+
+// ParseEncryptedPayload deserializes an EncryptedPayload from base64 strings.
+func ParseEncryptedPayload(version uint32, nonceB64, ciphertextB64 string) (EncryptedPayload, error) {
+	nonce, err := base64.RawURLEncoding.DecodeString(nonceB64)
+	if err != nil {
+		return EncryptedPayload{}, fmt.Errorf("decoding nonce: %w", err)
+	}
+	ct, err := base64.RawURLEncoding.DecodeString(ciphertextB64)
+	if err != nil {
+		return EncryptedPayload{}, fmt.Errorf("decoding ciphertext: %w", err)
+	}
+	return NewEncryptedPayload(version, nonce, ct), nil
+}
+
+// Encrypt encrypts plaintext using AES-256-GCM with a random nonce.
+// The masterKey must be 32 bytes. Returns an EncryptedPayload with version 0.
+func Encrypt(masterKey, plaintext []byte) (EncryptedPayload, error) {
+	return EncryptWithVersion(masterKey, plaintext, 0)
+}
+
+// EncryptWithVersion encrypts plaintext using AES-256-GCM with a random nonce.
+// version is included in the payload to support key rotation.
+func EncryptWithVersion(masterKey, plaintext []byte, version uint32) (EncryptedPayload, error) {
+	if len(masterKey) != KeySize {
+		return EncryptedPayload{}, ErrInvalidKeySize
+	}
+
+	block, err := aes.NewCipher(masterKey)
+	if err != nil {
+		return EncryptedPayload{}, fmt.Errorf("creating cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return EncryptedPayload{}, fmt.Errorf("creating GCM: %w", err)
+	}
+
+	nonce := make([]byte, NonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return EncryptedPayload{}, fmt.Errorf("generating nonce: %w", err)
+	}
+
+	// Prepend version to plaintext so it is authenticated by GCM along with the ciphertext.
+	// We encode the version as a 4-byte big-endian prefix.
+	prefixed := make([]byte, 4+len(plaintext))
+	putVersion(prefixed[:4], version)
+	copy(prefixed[4:], plaintext)
+
+	ciphertext := gcm.Seal(nil, nonce, prefixed, nil)
+
+	return NewEncryptedPayload(version, nonce, ciphertext), nil
+}
+
+// Decrypt decrypts a payload produced by Encrypt/EncryptWithVersion.
+// version is ignored at the crypto layer; callers can read it from the payload.
+func Decrypt(masterKey []byte, payload EncryptedPayload) ([]byte, error) {
+	return DecryptPayload(masterKey, payload.Version, payload.Nonce, payload.Ciphertext)
+}
+
+// DecryptPayload decrypts ciphertext given a version and base64-encoded nonce/ciphertext.
+func DecryptPayload(masterKey []byte, version uint32, nonceB64, ciphertextB64 string) ([]byte, error) {
+	if len(masterKey) != KeySize {
+		return nil, ErrInvalidKeySize
+	}
+
+	nonce, err := base64.RawURLEncoding.DecodeString(nonceB64)
+	if err != nil {
+		return nil, fmt.Errorf("decoding nonce: %w", err)
+	}
+	ciphertext, err := base64.RawURLEncoding.DecodeString(ciphertextB64)
+	if err != nil {
+		return nil, fmt.Errorf("decoding ciphertext: %w", err)
+	}
+	if len(ciphertext) < 4 {
+		return nil, ErrInvalidCiphertext
+	}
+
+	block, err := aes.NewCipher(masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("creating GCM: %w", err)
+	}
+
+	prefixed, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, ErrDecryptionFailed
+	}
+
+	// The first 4 bytes are the version prefix; they were authenticated by GCM.
+	// We could validate that prefixed[:4] matches the encoded version if desired,
+	// but the issue only requires key rotation support via nonce versioning,
+	// so we just strip the prefix.
+	payloadVersion := getVersion(prefixed[:4])
+	if payloadVersion != version {
+		// This shouldn't happen with a correct implementation, but guard anyway.
+		return nil, fmt.Errorf("version mismatch: expected %d, got %d", version, payloadVersion)
+	}
+
+	return prefixed[4:], nil
+}
+
+// putVersion writes v as big-endian into buf (len(buf) must be >= 4).
+func putVersion(buf []byte, v uint32) {
+	buf[0] = byte(v >> 24)
+	buf[1] = byte(v >> 16)
+	buf[2] = byte(v >> 8)
+	buf[3] = byte(v)
+}
+
+// getVersion reads a big-endian uint32 from buf (len(buf) must be >= 4).
+func getVersion(buf []byte) uint32 {
+	return uint32(buf[0])<<24 | uint32(buf[1])<<16 | uint32(buf[2])<<8 | uint32(buf[3])
+}
+
+// MustEncryptMasterKey reads and decodes the ENCRYPTION_MASTER_KEY env var.
+// It panics if the variable is missing or the key is not valid.
+func MustEncryptMasterKey() []byte {
+	raw := os.Getenv("ENCRYPTION_MASTER_KEY")
+	if raw == "" {
+		panic("ENCRYPTION_MASTER_KEY environment variable is not set")
+	}
+	key, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(raw))
+	if err != nil {
+		panic(fmt.Sprintf("ENCRYPTION_MASTER_KEY is not valid base64: %v", err))
+	}
+	if len(key) != KeySize {
+		panic(fmt.Sprintf("ENCRYPTION_MASTER_KEY must be %d bytes, got %d", KeySize, len(key)))
+	}
+	return key
+}
+
+// NewEncryptor returns an EncryptedPayload for the given plaintext using the loaded key.
+// Convenience wrapper around EncryptWithVersion using version 0.
+func NewEncryptor(masterKey []byte, plaintext []byte) (EncryptedPayload, error) {
+	return EncryptWithVersion(masterKey, plaintext, 0)
+}

--- a/internal/crypto/secrets.go
+++ b/internal/crypto/secrets.go
@@ -1,0 +1,223 @@
+package crypto
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog/log"
+)
+
+// ErrSecretNotFound is returned when a secret does not exist in the store.
+var ErrSecretNotFound = errors.New("secret not found")
+
+// SecretRecord represents a row in the encrypted_secrets table.
+type SecretRecord struct {
+	ID        int64
+	Namespace string // e.g. "pbx", "pms", "tenant:<id>"
+	Name      string
+	KeyVersion uint32
+	Nonce     string // base64 RawURL
+	Ciphertext string // base64 RawURL
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// SecretsStore provides encrypted credential storage backed by a database table.
+//
+// The table schema (created automatically via InitSchema):
+//
+//	CREATE TABLE IF NOT EXISTS encrypted_secrets (
+//	    id         BIGSERIAL PRIMARY KEY,
+//	    namespace  TEXT NOT NULL,
+//	    name       TEXT NOT NULL,
+//	    key_version INTEGER NOT NULL DEFAULT 0,
+//	    nonce      TEXT NOT NULL,
+//	    ciphertext TEXT NOT NULL,
+//	    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+//	    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+//	    UNIQUE (namespace, name)
+//	);
+//
+//	CREATE INDEX IF NOT EXISTS idx_encrypted_secrets_ns_name ON encrypted_secrets (namespace, name);
+type SecretsStore struct {
+	pool      *pgxpool.Pool
+	masterKey []byte
+}
+
+// NewSecretsStore creates a SecretsStore backed by the given pgxpool.
+// The masterKey must be 32 bytes.
+func NewSecretsStore(pool *pgxpool.Pool, masterKey []byte) (*SecretsStore, error) {
+	if len(masterKey) != KeySize {
+		return nil, ErrInvalidKeySize
+	}
+	return &SecretsStore{pool: pool, masterKey: masterKey}, nil
+}
+
+// InitSchema creates the encrypted_secrets table if it does not exist.
+func (s *SecretsStore) InitSchema(ctx context.Context) error {
+	schema := `
+	CREATE TABLE IF NOT EXISTS encrypted_secrets (
+		id          BIGSERIAL PRIMARY KEY,
+		namespace   TEXT    NOT NULL,
+		name        TEXT    NOT NULL,
+		key_version INTEGER NOT NULL DEFAULT 0,
+		nonce       TEXT    NOT NULL,
+		ciphertext  TEXT    NOT NULL,
+		created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+		updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+		UNIQUE (namespace, name)
+	);
+	CREATE INDEX IF NOT EXISTS idx_encrypted_secrets_ns_name ON encrypted_secrets (namespace, name);
+	`
+	_, err := s.pool.ExecContext(ctx, schema)
+	if err != nil {
+		return fmt.Errorf("creating encrypted_secrets schema: %w", err)
+	}
+	return nil
+}
+
+// StoreSecret encrypts and stores a secret. If the secret already exists it is updated.
+func (s *SecretsStore) StoreSecret(ctx context.Context, namespace, name string, plaintext []byte) error {
+	return s.StoreSecretWithVersion(ctx, namespace, name, plaintext, 0)
+}
+
+// StoreSecretWithVersion encrypts and stores a secret with an explicit key version.
+// This should be used during key rotation to record which version of the master key
+// was used to encrypt the value.
+func (s *SecretsStore) StoreSecretWithVersion(ctx context.Context, namespace, name string, plaintext []byte, version uint32) error {
+	payload, err := EncryptWithVersion(s.masterKey, plaintext, version)
+	if err != nil {
+		return fmt.Errorf("encrypting secret: %w", err)
+	}
+
+	_, err = s.pool.ExecContext(ctx, `
+		INSERT INTO encrypted_secrets (namespace, name, key_version, nonce, ciphertext, updated_at)
+		VALUES ($1, $2, $3, $4, $5, NOW())
+		ON CONFLICT (namespace, name) DO UPDATE SET
+			key_version = EXCLUDED.key_version,
+			nonce       = EXCLUDED.nonce,
+			ciphertext  = EXCLUDED.ciphertext,
+			updated_at  = NOW()
+	`, namespace, name, payload.Version, payload.Nonce, payload.Ciphertext)
+	if err != nil {
+		return fmt.Errorf("upserting secret: %w", err)
+	}
+
+	log.Debug().Str("namespace", namespace).Str("name", name).Msg("Secret stored")
+	return nil
+}
+
+// GetSecret retrieves and decrypts a secret. Returns ErrSecretNotFound if missing.
+func (s *SecretsStore) GetSecret(ctx context.Context, namespace, name string) ([]byte, error) {
+	var rec SecretRecord
+	err := s.pool.QueryRowContext(ctx, `
+		SELECT id, namespace, name, key_version, nonce, ciphertext, created_at, updated_at
+		FROM encrypted_secrets WHERE namespace = $1 AND name = $2
+	`, namespace, name).Scan(
+		&rec.ID, &rec.Namespace, &rec.Name, &rec.KeyVersion,
+		&rec.Nonce, &rec.Ciphertext, &rec.CreatedAt, &rec.UpdatedAt,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, ErrSecretNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying secret: %w", err)
+	}
+
+	plaintext, err := DecryptPayload(s.masterKey, rec.KeyVersion, rec.Nonce, rec.Ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("decrypting secret: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// RotateSecret re-encrypts an existing secret with a new key version and stores it.
+// If the secret does not exist, returns ErrSecretNotFound.
+// This does NOT invalidate the old version; callers should ensure the old key
+// material remains available for decryption of older ciphertexts during a
+// rotation window, or re-encrypt all secrets sequentially during a key change.
+func (s *SecretsStore) RotateSecret(ctx context.Context, namespace, name string, newPlaintext []byte, newVersion uint32) error {
+	// Verify the secret exists first
+	var exists bool
+	err := s.pool.QueryRowContext(ctx, `
+		SELECT EXISTS(SELECT 1 FROM encrypted_secrets WHERE namespace = $1 AND name = $2)
+	`, namespace, name).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("checking secret existence: %w", err)
+	}
+	if !exists {
+		return ErrSecretNotFound
+	}
+
+	return s.StoreSecretWithVersion(ctx, namespace, name, newPlaintext, newVersion)
+}
+
+// DeleteSecret removes a secret. Returns ErrSecretNotFound if it did not exist.
+func (s *SecretsStore) DeleteSecret(ctx context.Context, namespace, name string) error {
+	result, err := s.pool.ExecContext(ctx, `
+		DELETE FROM encrypted_secrets WHERE namespace = $1 AND name = $2
+	`, namespace, name)
+	if err != nil {
+		return fmt.Errorf("deleting secret: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrSecretNotFound
+	}
+	return nil
+}
+
+// ListSecrets returns the metadata (namespace, name, version, timestamps) of all
+// secrets in a namespace. The plaintext values are NOT included.
+func (s *SecretsStore) ListSecrets(ctx context.Context, namespace string) ([]SecretRecord, error) {
+	rows, err := s.pool.QueryContext(ctx, `
+		SELECT id, namespace, name, key_version, nonce, ciphertext, created_at, updated_at
+		FROM encrypted_secrets WHERE namespace = $1 ORDER BY name
+	`, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("listing secrets: %w", err)
+	}
+	defer rows.Close()
+
+	var records []SecretRecord
+	for rows.Next() {
+		var r SecretRecord
+		if err := rows.Scan(&r.ID, &r.Namespace, &r.Name, &r.KeyVersion,
+			&r.Nonce, &r.Ciphertext, &r.CreatedAt, &r.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scanning secret row: %w", err)
+		}
+		records = append(records, r)
+	}
+	return records, rows.Err()
+}
+
+// SecretJSON is a helper for storing JSON-serialisable structs as encrypted secrets.
+// Use StoreJSON/GetJSON for convenience.
+func (s *SecretsStore) StoreJSON(ctx context.Context, namespace, name string, v interface{}) error {
+	plaintext, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshalling JSON: %w", err)
+	}
+	return s.StoreSecret(ctx, namespace, name, plaintext)
+}
+
+// GetJSON retrieves a secret and deserialises it as JSON into v.
+func (s *SecretsStore) GetJSON(ctx context.Context, namespace, name string, v interface{}) error {
+	plaintext, err := s.GetSecret(ctx, namespace, name)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(plaintext, v); err != nil {
+		return fmt.Errorf("unmarshalling JSON: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements the AES-256-GCM encryption layer for storing credentials at rest, as requested in TOP-19.

### Files created

- **`internal/crypto/crypto.go`**
  - `Encrypt` / `EncryptWithVersion` — AES-256-GCM with a random 12-byte nonce; version is embedded as an authenticated 4-byte prefix so GCM verifies it during decryption
  - `Decrypt` / `DecryptPayload` — decrypts; GCM authentication rejects any tampered ciphertext
  - `MustEncryptMasterKey` — reads the `ENCRYPTION_MASTER_KEY` env var (base64 RawURL 32-byte key), panics if missing or malformed
  - `EncryptedPayload` struct uses `base64.RawURLEncoding` for nonce and ciphertext (no `+`/`=` chars, safe in JSON/config)

- **`internal/crypto/secrets.go`**
  - `SecretsStore` backed by PostgreSQL via `*pgxpool.Pool` (matches existing `db.DB` type)
  - `InitSchema` — creates the `encrypted_secrets` table automatically
  - `StoreSecret` / `StoreSecretWithVersion` — encrypts and upserts a secret
  - `GetSecret` — retrieves and decrypts; returns `ErrSecretNotFound` if missing
  - `RotateSecret` — re-encrypts an existing secret with a new key version
  - `DeleteSecret` / `ListSecrets` — remove and list secrets (metadata only, no plaintext)
  - `StoreJSON` / `GetJSON` — convenience wrappers for JSON-serialisable structs

### DB schema

```sql
CREATE TABLE IF NOT EXISTS encrypted_secrets (
    id          BIGSERIAL PRIMARY KEY,
    namespace   TEXT    NOT NULL,
    name        TEXT    NOT NULL,
    key_version INTEGER NOT NULL DEFAULT 0,
    nonce       TEXT    NOT NULL,
    ciphertext  TEXT    NOT NULL,
    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    UNIQUE (namespace, name)
);
CREATE INDEX IF NOT EXISTS idx_encrypted_secrets_ns_name ON encrypted_secrets (namespace, name);
```

### Key rotation design

Each secret stores a `key_version`. During rotation the caller re-encrypts with a new version; old key material must be retained during the transition window so existing ciphertexts can still be decrypted. `RotateSecret` verifies existence before writing to avoid silent creation.

### Usage

```go
secrets, err := crypto.NewSecretsStore(database.Pool(), crypto.MustEncryptMasterKey())
if err := secrets.InitSchema(ctx); err != nil {
    log.Fatal().Err(err)
}

// Store a secret
if err := secrets.StoreSecret(ctx, "pbx:tenant-1", "ari_password", []byte("secret123")); err != nil {
    log.Fatal().Err(err)
}

// Retrieve it
plaintext, err := secrets.GetSecret(ctx, "pbx:tenant-1", "ari_password")
```

Closes TOP-19
