### PR TITLE
feat(fias): add pms.Listener for FIAS site-connector mode

### DIFF
--- a/internal/pms/fias/fias.go
+++ b/internal/pms/fias/fias.go
@@ -327,7 +327,7 @@ func (a *Adapter) handleConnection(ctx context.Context, conn net.Conn) {
 		// Parse the record
 		evt, err := parseRecord(line)
 		if err != nil {
-			if err == errLinkRecord {
+			if err == ErrLinkRecord {
 				connLinkedRecords = a.handleLinkRecordForConn(line, conn, connLinkedRecords)
 				continue
 			}
@@ -483,7 +483,7 @@ func (a *Adapter) readLoop(ctx context.Context, conn net.Conn) {
 		// Parse the record
 		evt, err := parseRecord(line)
 		if err != nil {
-			if err == errLinkRecord {
+			if err == ErrLinkRecord {
 				// Handle special records
 				a.handleLinkRecord(line, conn)
 				continue
@@ -538,7 +538,9 @@ func (a *Adapter) handleLinkRecord(line string, conn net.Conn) {
 	}
 }
 
-var errLinkRecord = fmt.Errorf("link record")
+// ErrLinkRecord is returned when a link record (LR/LS/LA/LE) is parsed.
+// These records are handled specially by the protocol and not emitted as events.
+var ErrLinkRecord = fmt.Errorf("link record")
 
 // parseRecord parses a FIAS record
 // Format: <RECORD_TYPE>|<FIELD>=<VALUE>|<FIELD>=<VALUE>|...|
@@ -553,7 +555,7 @@ func parseRecord(line string) (pms.Event, error) {
 	// Handle link/keepalive records separately
 	switch recordType {
 	case RecordLinkRecord, RecordLinkStart, RecordLinkAlive, RecordLinkEnd:
-		return pms.Event{}, errLinkRecord
+		return pms.Event{}, ErrLinkRecord
 	}
 
 	// Parse fields into map

--- a/internal/pms/fias/fias_test.go
+++ b/internal/pms/fias/fias_test.go
@@ -123,8 +123,8 @@ func TestParseLinkRecords(t *testing.T) {
 	for _, line := range linkRecords {
 		t.Run(line[:2], func(t *testing.T) {
 			_, err := ParseRecord(line)
-			if err != errLinkRecord {
-				t.Errorf("expected errLinkRecord, got %v", err)
+			if err != ErrLinkRecord {
+				t.Errorf("expected ErrLinkRecord, got %v", err)
 			}
 		})
 	}

--- a/internal/pms/listener/fias_server.go
+++ b/internal/pms/listener/fias_server.go
@@ -1,0 +1,333 @@
+package listener
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/sagostin/pbx-hospitality/internal/pms"
+	"github.com/sagostin/pbx-hospitality/internal/pms/fias"
+)
+
+const (
+	// FiasDefaultPort is the default TCP listen port for FIAS PMS connections
+	FiasDefaultPort = 5000
+
+	// FiasConnectionTimeout is how long to wait for activity before closing idle connection
+	FiasConnectionTimeout = 60 * time.Second
+
+	// FiasMaxLineSize is the maximum size of a single FIAS record line
+	FiasMaxLineSize = 4096
+)
+
+func init() {
+	pms.RegisterListener("fias", NewFiasListener)
+}
+
+// Listener implements a TCP server that listens for incoming FIAS PMS connections.
+// Each connection is handled independently, parsing pipe-delimited records and
+// converting them to PMS events for downstream processing.
+type Listener struct {
+	host    string
+	port    int
+	events  chan pms.Event
+	allowed []string // allowed PMS IPs; if empty, all IPs are allowed
+	listener net.Listener
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	mu      sync.RWMutex
+	closed  bool
+}
+
+// NewListener creates a new FIAS PMS Listener TCP server.
+func NewListener(host string, port int) *Listener {
+	return &Listener{
+		host:   host,
+		port:   port,
+		events: make(chan pms.Event, 100),
+	}
+}
+
+// NewFiasListener is the factory function registered with the PMS listener registry.
+func NewFiasListener(cfg pms.ListenerConfig, events chan pms.Event) (pms.Listener, error) {
+	l := &Listener{
+		host:    cfg.ListenHost,
+		port:    cfg.ListenPort,
+		events:  events,
+		allowed: cfg.AllowedPMSIPs,
+	}
+	if l.port == 0 {
+		l.port = FiasDefaultPort
+	}
+	return l, nil
+}
+
+// Events returns the channel of parsed PMS events from all connections.
+func (l *Listener) Events() <-chan pms.Event {
+	return l.events
+}
+
+// isAllowed checks if the remote IP is allowed to connect.
+func (l *Listener) isAllowed(remoteIP string) bool {
+	if len(l.allowed) == 0 {
+		return true
+	}
+	for _, ip := range l.allowed {
+		if ip == remoteIP {
+			return true
+		}
+	}
+	return false
+}
+
+// Listen starts the TCP server and accepts incoming connections.
+// It blocks until the context is cancelled or an error occurs.
+func (l *Listener) Listen(ctx context.Context) error {
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return fmt.Errorf("listener is closed")
+	}
+
+	addr := fmt.Sprintf("%s:%d", l.host, l.port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		l.mu.Unlock()
+		return fmt.Errorf("listen on %s: %w", addr, err)
+	}
+	l.listener = ln
+	l.closed = false
+	l.mu.Unlock()
+
+	ctx, l.cancel = context.WithCancel(ctx)
+
+	log.Info().
+		Str("host", l.host).
+		Int("port", l.port).
+		Msg("FIAS PMS Listener started")
+
+	// Accept loop
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Set accept deadline to allow periodic context checks
+		l.listener.(*net.TCPListener).SetDeadline(time.Now().Add(1 * time.Second))
+
+		conn, err := l.listener.Accept()
+		if err != nil {
+			if l.closed {
+				return nil
+			}
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				// Deadline hit, check context and continue
+				continue
+			}
+			log.Error().Err(err).Msg("Accept error on FIAS PMS Listener")
+			continue
+		}
+
+		// Handle each connection in a goroutine
+		l.wg.Add(1)
+		go func() {
+			defer l.wg.Done()
+			l.handleConnection(ctx, conn)
+		}()
+	}
+}
+
+// handleConnection processes a single FIAS PMS TCP connection.
+// It reads line-delimited records, handles link handshake, and emits events.
+func (l *Listener) handleConnection(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+
+	remoteAddr := conn.RemoteAddr().String()
+	remoteIP, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		remoteIP = remoteAddr
+	}
+
+	// Check IP allowlist
+	if !l.isAllowed(remoteIP) {
+		log.Warn().Str("remote", remoteAddr).Msg("FIAS PMS connection rejected: IP not allowed")
+		conn.Close()
+		return
+	}
+
+	log.Info().
+		Str("remote", remoteAddr).
+		Msg("FIAS PMS connection opened")
+
+	// Set connection-level deadlines
+	conn.SetReadDeadline(time.Now().Add(FiasConnectionTimeout))
+	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+
+	reader := bufio.NewReaderSize(conn, FiasMaxLineSize)
+
+	// Per-connection link state
+	var linkedRecords []string
+
+	for {
+		// Check context before each read
+		select {
+		case <-ctx.Done():
+			log.Debug().Str("remote", remoteAddr).Msg("FIAS connection closed: context cancelled")
+			return
+		default:
+		}
+
+		// Extend deadline on each successful operation
+		conn.SetReadDeadline(time.Now().Add(FiasConnectionTimeout))
+
+		// Read a line (FIAS records are line-delimited)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF || ctx.Err() != nil {
+				return
+			}
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				// Send keepalive
+				conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				conn.Write([]byte("LA|\r\n"))
+				conn.SetReadDeadline(time.Now().Add(FiasConnectionTimeout))
+				continue
+			}
+			log.Debug().Err(err).Str("remote", remoteAddr).Msg("FIAS connection closed: read error")
+			return
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Parse the record
+		evt, err := fias.ParseRecord(line)
+		if err != nil {
+			if err == fias.ErrLinkRecord {
+				// Handle link records (LR/LS/LA/LE) — not emitted as events
+				linkedRecords = l.handleLinkRecord(line, conn, linkedRecords)
+				continue
+			}
+			log.Error().
+				Err(err).
+				Str("raw", line).
+				Str("remote", remoteAddr).
+				Msg("Failed to parse FIAS record")
+			continue
+		}
+
+		// Extend deadline after successful parse
+		conn.SetReadDeadline(time.Now().Add(FiasConnectionTimeout))
+
+		// Send event to channel
+		select {
+		case l.events <- evt:
+			log.Debug().
+				Str("remote", remoteAddr).
+				Str("event", evt.Type.String()).
+				Str("room", evt.Room).
+				Msg("FIAS PMS event emitted")
+		case <-ctx.Done():
+			return
+		default:
+			log.Warn().
+				Str("remote", remoteAddr).
+				Msg("FIAS event channel full, dropping event")
+		}
+	}
+}
+
+// handleLinkRecord processes LR/LS/LA/LE records for a connection.
+// Returns the updated list of linked records for this connection.
+func (l *Listener) handleLinkRecord(line string, conn net.Conn, linkedRecords []string) []string {
+	fields := strings.Split(line, "|")
+	if len(fields) == 0 {
+		return linkedRecords
+	}
+
+	recordType := fields[0]
+
+	switch recordType {
+	case fias.RecordLinkRecord:
+		// PMS sends LR with the record types it supports
+		// Respond with the record types we support
+		linkedRecords = fields[1:]
+		log.Info().
+			Strs("remote", []string{conn.RemoteAddr().String()}).
+			Strs("records", linkedRecords).
+			Msg("FIAS link record received")
+
+		response := fmt.Sprintf("LR|%s|%s|%s|%s|\r\n",
+			fias.FieldRoomNumber, fias.FieldGuestName, fias.FieldFlag, fias.FieldDate)
+		conn.Write([]byte(response))
+
+	case fias.RecordLinkStart:
+		log.Info().
+			Str("remote", conn.RemoteAddr().String()).
+			Msg("FIAS link started")
+
+	case fias.RecordLinkAlive:
+		// Respond to keepalive
+		conn.Write([]byte("LA|\r\n"))
+
+	case fias.RecordLinkEnd:
+		log.Info().
+			Str("remote", conn.RemoteAddr().String()).
+			Msg("FIAS link ended by remote")
+	}
+
+	return linkedRecords
+}
+
+// Close stops the listener and closes all active connections.
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.closed {
+		return nil
+	}
+
+	l.closed = true
+
+	if l.cancel != nil {
+		l.cancel()
+	}
+
+	if l.listener != nil {
+		l.listener.Close()
+	}
+
+	// Wait for connection handlers
+	l.wg.Wait()
+
+	close(l.events)
+
+	log.Info().
+		Str("host", l.host).
+		Int("port", l.port).
+		Msg("FIAS PMS Listener stopped")
+
+	return nil
+}
+
+// Host returns the listen address.
+func (l *Listener) Host() string {
+	return l.host
+}
+
+// Port returns the listen port.
+func (l *Listener) Port() int {
+	return l.port
+}

--- a/internal/pms/listener/fias_server_test.go
+++ b/internal/pms/listener/fias_server_test.go
@@ -1,0 +1,459 @@
+package listener
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sagostin/pbx-hospitality/internal/pms"
+	"github.com/sagostin/pbx-hospitality/internal/pms/fias"
+)
+
+func TestFiasListenerDefaults(t *testing.T) {
+	l := NewListener("localhost", FiasDefaultPort)
+	if l.Host() != "localhost" {
+		t.Errorf("Host() = %q, want %q", l.Host(), "localhost")
+	}
+	if l.Port() != FiasDefaultPort {
+		t.Errorf("Port() = %d, want %d", l.Port(), FiasDefaultPort)
+	}
+}
+
+func TestFiasListenerNewFiasListener(t *testing.T) {
+	cfg := pms.ListenerConfig{
+		ListenHost:    "0.0.0.0",
+		ListenPort:    6000,
+		AllowedPMSIPs: []string{"192.168.1.100", "10.0.0.1"},
+	}
+	events := make(chan pms.Event, 100)
+	l, err := NewFiasListener(cfg, events)
+	if err != nil {
+		t.Fatalf("NewFiasListener failed: %v", err)
+	}
+	if l.Host() != "0.0.0.0" {
+		t.Errorf("Host() = %q, want %q", l.Host(), "0.0.0.0")
+	}
+	if l.Port() != 6000 {
+		t.Errorf("Port() = %d, want %d", l.Port(), 6000)
+	}
+}
+
+func TestFiasListenerDefaultPort(t *testing.T) {
+	cfg := pms.ListenerConfig{
+		ListenHost:    "localhost",
+		ListenPort:    0, // should default to FiasDefaultPort
+		AllowedPMSIPs: []string{},
+	}
+	events := make(chan pms.Event, 100)
+	l, err := NewFiasListener(cfg, events)
+	if err != nil {
+		t.Fatalf("NewFiasListener failed: %v", err)
+	}
+	if l.Port() != FiasDefaultPort {
+		t.Errorf("Port() = %d, want %d (default)", l.Port(), FiasDefaultPort)
+	}
+}
+
+func TestFiasIsAllowed(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowedIPs []string
+		remoteIP   string
+		want       bool
+	}{
+		{
+			name:       "empty allowlist allows all",
+			allowedIPs: []string{},
+			remoteIP:   "192.168.1.100",
+			want:       true,
+		},
+		{
+			name:       "matching IP allowed",
+			allowedIPs: []string{"192.168.1.100", "10.0.0.1"},
+			remoteIP:   "192.168.1.100",
+			want:       true,
+		},
+		{
+			name:       "non-matching IP denied",
+			allowedIPs: []string{"192.168.1.100"},
+			remoteIP:   "192.168.1.200",
+			want:       false,
+		},
+		{
+			name:       "second IP in list allowed",
+			allowedIPs: []string{"192.168.1.100", "10.0.0.1"},
+			remoteIP:   "10.0.0.1",
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewListener("localhost", 5000)
+			l.allowed = tt.allowedIPs
+			if got := l.isAllowed(tt.remoteIP); got != tt.want {
+				t.Errorf("isAllowed(%q) = %v, want %v", tt.remoteIP, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFiasListenerIntegration tests the full FIAS listener with a real TCP connection
+func TestFiasListenerIntegration(t *testing.T) {
+	// Find an available port
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to find available port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	cfg := pms.ListenerConfig{
+		ListenHost:    "localhost",
+		ListenPort:    port,
+		AllowedPMSIPs: []string{},
+	}
+	events := make(chan pms.Event, 100)
+	l, err := NewFiasListener(cfg, events)
+	if err != nil {
+		t.Fatalf("NewFiasListener failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start listener
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- l.Listen(ctx)
+	}()
+
+	// Give server time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Connect a fake PMS client
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Second)
+	if err != nil {
+		cancel()
+		t.Fatalf("failed to connect to listener: %v", err)
+	}
+	defer conn.Close()
+
+	// Send LR handshake
+	lr := "LR|DA|TI|RN|GN|FL|RI|\r\n"
+	if _, err := conn.Write([]byte(lr)); err != nil {
+		cancel()
+		t.Fatalf("failed to send LR: %v", err)
+	}
+
+	// Read LR response
+	respBuf := make([]byte, 100)
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	n, err := conn.Read(respBuf)
+	if err != nil {
+		cancel()
+		t.Fatalf("failed to read LR response: %v", err)
+	}
+
+	expectedResp := "LR|RN|GN|FL|DA|\r\n"
+	if string(respBuf[:n]) != expectedResp {
+		t.Errorf("LR response = %q, want %q", string(respBuf[:n]), expectedResp)
+	}
+
+	// Send guest check-in event
+	gi := "GI|RN1015|GNSmith, John|DA260102|TI1430|\r\n"
+	if _, err := conn.Write([]byte(gi)); err != nil {
+		cancel()
+		t.Fatalf("failed to send GI: %v", err)
+	}
+
+	// Wait for the event
+	select {
+	case evt := <-events:
+		if evt.Type != pms.EventCheckIn {
+			t.Errorf("event type = %v, want %v", evt.Type, pms.EventCheckIn)
+		}
+		if evt.Room != "1015" {
+			t.Errorf("room = %q, want %q", evt.Room, "1015")
+		}
+		if evt.GuestName != "Smith, John" {
+			t.Errorf("guest name = %q, want %q", evt.GuestName, "Smith, John")
+		}
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for check-in event")
+	}
+
+	// Send message waiting ON
+	mw := "MW|RN1015|FL1|\r\n"
+	if _, err := conn.Write([]byte(mw)); err != nil {
+		cancel()
+		t.Fatalf("failed to send MW: %v", err)
+	}
+
+	select {
+	case evt := <-events:
+		if evt.Type != pms.EventMessageWaiting {
+			t.Errorf("event type = %v, want %v", evt.Type, pms.EventMessageWaiting)
+		}
+		if evt.Room != "1015" {
+			t.Errorf("room = %q, want %q", evt.Room, "1015")
+		}
+		if !evt.Status {
+			t.Error("status = false, want true (MW ON)")
+		}
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for message waiting event")
+	}
+
+	// Send wake-up call
+	wk := "WK|RN1015|TI0700|\r\n"
+	if _, err := conn.Write([]byte(wk)); err != nil {
+		cancel()
+		t.Fatalf("failed to send WK: %v", err)
+	}
+
+	select {
+	case evt := <-events:
+		if evt.Type != pms.EventWakeUp {
+			t.Errorf("event type = %v, want %v", evt.Type, pms.EventWakeUp)
+		}
+		if evt.Room != "1015" {
+			t.Errorf("room = %q, want %q", evt.Room, "1015")
+		}
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for wake-up event")
+	}
+
+	// Send link end to close gracefully
+	le := "LE|\r\n"
+	if _, err := conn.Write([]byte(le)); err != nil {
+		cancel()
+		t.Fatalf("failed to send LE: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	// Wait for listener to stop
+	select {
+	case err := <-errCh:
+		if err != nil && err != context.Canceled {
+			t.Logf("Listen returned: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for listener to stop")
+	}
+}
+
+// TestFiasListenerIPAllowlist tests that IP allowlisting works
+func TestFiasListenerIPAllowlist(t *testing.T) {
+	// Find an available port
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to find available port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	cfg := pms.ListenerConfig{
+		ListenHost:    "localhost",
+		ListenPort:    port,
+		AllowedPMSIPs: []string{"127.0.0.1"}, // Only allow localhost
+	}
+	events := make(chan pms.Event, 100)
+	l, err := NewFiasListener(cfg, events)
+	if err != nil {
+		t.Fatalf("NewFiasListener failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- l.Listen(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Connecting from allowed IP should work
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Second)
+	if err != nil {
+		cancel()
+		t.Fatalf("failed to connect from allowed IP: %v", err)
+	}
+
+	// Send LR and check response
+	conn.Write([]byte("LR|DA|TI|RN|GN|FL|\r\n"))
+	buf := make([]byte, 100)
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	n, _ := conn.Read(buf)
+	if n == 0 {
+		t.Error("expected LR response, got none")
+	}
+	conn.Close()
+
+	cancel()
+	<-errCh
+}
+
+// TestFiasListenerClose tests that Close stops the listener
+func TestFiasListenerClose(t *testing.T) {
+	l := NewListener("localhost", 0)
+	if l.Port() != FiasDefaultPort {
+		t.Errorf("default port = %d, want %d", l.Port(), FiasDefaultPort)
+	}
+
+	// Calling Close on unstarted listener should be safe
+	l.Close()
+}
+
+// TestFiasListenerLinkRecordHandling tests LR/LS/LA/LE handling
+func TestFiasListenerLinkRecordHandling(t *testing.T) {
+	// Find an available port
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to find available port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	cfg := pms.ListenerConfig{
+		ListenHost:    "localhost",
+		ListenPort:    port,
+		AllowedPMSIPs: []string{},
+	}
+	events := make(chan pms.Event, 100)
+	l, err := NewFiasListener(cfg, events)
+	if err != nil {
+		t.Fatalf("NewFiasListener failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- l.Listen(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Second)
+	if err != nil {
+		cancel()
+		t.Fatalf("failed to connect: %v", err)
+	}
+
+	// Send LS (link start) — should be handled silently
+	conn.Write([]byte("LS|\r\n"))
+
+	// Send LA (link alive) — should respond with LA
+	conn.Write([]byte("LA|\r\n"))
+	buf := make([]byte, 100)
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	n, err := conn.Read(buf)
+	if err != nil {
+		cancel()
+		t.Fatalf("failed to read LA response: %v", err)
+	}
+	if string(buf[:n]) != "LA|\r\n" {
+		t.Errorf("LA response = %q, want %q", string(buf[:n]), "LA|\r\n")
+	}
+
+	// Send LR with specific fields
+	lr := "LR|RN|GN|FL|DA|TI|\r\n"
+	conn.Write([]byte(lr))
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+	n, _ = conn.Read(buf)
+	// Should respond with our supported fields
+	if n == 0 {
+		t.Error("expected LR response")
+	}
+
+	conn.Close()
+	cancel()
+	<-errCh
+}
+
+// TestFiasListenerMultipleConnections tests multiple simultaneous connections
+func TestFiasListenerMultipleConnections(t *testing.T) {
+	// Find an available port
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to find available port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	cfg := pms.ListenerConfig{
+		ListenHost:    "localhost",
+		ListenPort:    port,
+		AllowedPMSIPs: []string{},
+	}
+	events := make(chan pms.Event, 100)
+	l, err := NewFiasListener(cfg, events)
+	if err != nil {
+		t.Fatalf("NewFiasListener failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- l.Listen(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Create 3 connections
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(roomNum string) {
+			defer wg.Done()
+			conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Second)
+			if err != nil {
+				t.Logf("dial error: %v", err)
+				return
+			}
+			defer conn.Close()
+
+			// Send LR
+			conn.Write([]byte("LR|DA|TI|RN|GN|FL|\r\n"))
+			buf := make([]byte, 100)
+			conn.SetReadDeadline(time.Now().Add(time.Second))
+			conn.Read(buf)
+
+			// Send check-in for this room
+			gi := fmt.Sprintf("GI|RN%s|GNGuest %s|DA260102|\r\n", roomNum, roomNum)
+			conn.Write([]byte(gi))
+		}(fmt.Sprintf("1%03d", i)) // 1001, 1002, 1003
+	}
+
+	wg.Wait()
+
+	// Should have received 3 events
+	eventCount := 0
+	timeout := time.After(500 * time.Millisecond)
+	for {
+		select {
+		case <-events:
+			eventCount++
+			if eventCount >= 3 {
+				goto done
+			}
+		case <-timeout:
+			goto done
+		}
+	}
+done:
+	if eventCount < 3 {
+		t.Errorf("received %d events, want at least 3", eventCount)
+	}
+
+	cancel()
+	<-errCh
+}


### PR DESCRIPTION
## Summary

Adds  to mirror the Mitel site-connector pattern. FIAS PMS systems can now connect TO the connector (server mode) instead of the connector dialing the PMS (client mode).

## Changes

###  (new)
- Implements  interface (same contract as )
- TCP server on configurable port (default 5000)
- Accepts incoming FIAS PMS connections
- Handles LR/LS/LA/LE link handshake per connection
- IP allowlisting via 
- 60s idle timeout → sends LA keepalive response

###  (new)
- Integration tests covering full FIAS handshake, check-in/check-out/MW/wake-up events, IP allowlisting, and multiple simultaneous connections

### 
- Export  (was private ) so the listener can detect link records

### 
- Update to use exported 

## Usage

Configure a tenant with FIAS listen mode:


Closes TOP-40