### PR TITLE
config: remove tenants from config.yaml, DB-first architecture

### DIFF
--- a/cmd/bicom-hospitality/main.go
+++ b/cmd/bicom-hospitality/main.go
@@ -87,9 +87,14 @@ func main() {
 	}
 
 	// Initialize tenant manager
-	tm, err := tenant.NewManager(cfg, database)
+	tm, err := tenant.NewManager(database)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize tenant manager")
+	}
+
+	// Load tenants from database
+	if err := tm.LoadFromDB(ctx); err != nil {
+		log.Fatal().Err(err).Msg("Failed to load tenants from database")
 	}
 
 	// Start all tenants
@@ -119,9 +124,6 @@ func main() {
 			log.Fatal().Err(err).Msg("HTTP server failed")
 		}
 	}()
-
-	// Start config reload handler (SIGHUP)
-	go handleConfigReload(tm)
 
 	// Wait for interrupt signal
 	quit := make(chan os.Signal, 1)
@@ -177,9 +179,15 @@ func runHealthCheck(cfg *config.Config) int {
 	}
 
 	// Initialize tenant manager
-	tm, err := tenant.NewManager(cfg, database)
+	tm, err := tenant.NewManager(database)
 	if err != nil {
 		log.Error().Err(err).Msg("Health check: failed to initialize tenant manager")
+		return 1
+	}
+
+	// Load tenants from DB
+	if err := tm.LoadFromDB(ctx); err != nil {
+		log.Error().Err(err).Msg("Health check: failed to load tenants from DB")
 		return 1
 	}
 
@@ -195,29 +203,4 @@ func runHealthCheck(cfg *config.Config) int {
 
 	log.Info().Msg("Health check passed")
 	return 0
-}
-
-// handleConfigReload listens for SIGHUP and reloads configuration
-func handleConfigReload(tm *tenant.Manager) {
-	sighup := make(chan os.Signal, 1)
-	signal.Notify(sighup, syscall.SIGHUP)
-
-	for {
-		<-sighup
-		log.Info().Msg("Received SIGHUP, reloading configuration...")
-
-		newCfg, err := config.Load()
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to reload configuration")
-			continue
-		}
-
-		// Reload tenant configurations
-		if err := tm.Reload(newCfg); err != nil {
-			log.Error().Err(err).Msg("Failed to reload tenants")
-			continue
-		}
-
-		log.Info().Int("tenants", len(newCfg.Tenants)).Msg("Configuration reloaded successfully")
-	}
 }

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -5,60 +5,16 @@ server:
   port: 8080
 
 database:
-  host: localhost
+  host: "10.0.0.5"
   port: 5432
-  user: hospitality
-  password: ${DB_PASSWORD}
-  database: hospitality
-  ssl_mode: disable
+  user: "hospitality"
+  password: "${DB_PASSWORD}"
+  database: "hospitality"
+  ssl_mode: "require"
 
-tenants:
-  # ==========================================================================
-  # Bicom PBXware Tenant (Asterisk-based with ARI)
-  # ==========================================================================
-  - id: hotel-alpha
-    name: "Hotel Alpha"
-    enabled: true
-    timezone: "America/New_York"
-    region: "us-east"
-    pms:
-      protocol: mitel
-      host: 10.0.1.50
-      port: 23
-    pbx:
-      type: bicom  # Optional, this is the default
-      # ARI settings for real-time call control
-      ari_url: "http://pbx.alpha.local:8088/ari"
-      ari_ws_url: "ws://pbx.alpha.local:8088/ari/events"
-      ari_user: "hotel-alpha"
-      ari_pass: "${HOTEL_ALPHA_ARI_SECRET}"
-      app_name: "hospitality-alpha"
-      # Bicom REST API for extension/voicemail management
-      api_url: "https://pbx.alpha.local"
-      api_key: "${HOTEL_ALPHA_API_KEY}"
-      tenant_id: "1"
-    room_prefix: "1"
+crypto:
+  master_key: "${ENCRYPTION_MASTER_KEY}"
 
-  # ==========================================================================
-  # Zultys MX Tenant (Webhook-based with session auth)
-  # ==========================================================================
-  - id: hotel-zultys
-    name: "Hotel Zultys"
-    enabled: true
-    timezone: "America/Los_Angeles"
-    region: "us-west"
-    pms:
-      protocol: fias
-      host: 10.0.3.50
-      port: 3722
-    pbx:
-      type: zultys
-      # Zultys REST API (session-based auth)
-      api_url: "https://zultys.hotel.com/api"
-      auth_url: "/auth/login"
-      username: "${ZULTYS_USERNAME}"
-      password: "${ZULTYS_PASSWORD}"
-      # Inbound webhook validation secret
-      webhook_secret: "${ZULTYS_WEBHOOK_SECRET}"
-    room_prefix: "3"
-    # Note: Wake-up calls not supported on Zultys (requires external scheduler)
+logging:
+  level: "info"
+  format: "json"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,34 +141,51 @@ graph LR
 
 ### Tenant Configuration
 
+In the DB-first architecture, tenant configuration is managed entirely through the database and Admin API. The `config.yaml` file contains only server-level settings.
+
+**config.yaml (server settings only):**
 ```yaml
-tenants:
-  - id: hotel-alpha
-    name: "Hotel Alpha"
-    pms:
-      protocol: fias
-      host: 10.0.1.50
-      port: 3722
-    pbx:
-      ari_url: "http://pbx.alpha.local:8088/ari"
-      ari_user: "hotel-alpha"
-      ari_pass: "${HOTEL_ALPHA_ARI_SECRET}"
-      tenant_id: "alpha"
-    room_prefix: "1"    # Rooms 100-199 → Extensions 1100-1199
-    
-  - id: hotel-beta
-    name: "Hotel Beta"
-    pms:
-      protocol: mitel
-      host: 10.0.2.50
-      port: 23
-    pbx:
-      ari_url: "http://pbx.beta.local:8088/ari"
-      ari_user: "hotel-beta"
-      ari_pass: "${HOTEL_BETA_ARI_SECRET}"
-      tenant_id: "beta"
-    room_prefix: "2"
+server:
+  port: 8080
+
+database:
+  host: "10.0.0.5"
+  port: 5432
+  user: "hospitality"
+  password: "${DB_PASSWORD}"
+  database: "hospitality"
+  ssl_mode: "require"
+
+crypto:
+  master_key: "${ENCRYPTION_MASTER_KEY}"
+
+logging:
+  level: "info"
+  format: "json"
 ```
+
+**Database Schema (tenants table):**
+```sql
+CREATE TABLE tenants (
+    id          VARCHAR(64) PRIMARY KEY,
+    name        VARCHAR(255) NOT NULL,
+    pms_config  JSONB NOT NULL,
+    pbx_config  JSONB NOT NULL,
+    settings    JSONB DEFAULT '{}',
+    enabled     BOOLEAN DEFAULT true,
+    created_at  TIMESTAMPTZ DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+**Admin API for Tenant Management:**
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/v1/tenants` | List all tenants |
+| `POST` | `/api/v1/tenants` | Create tenant |
+| `GET` | `/api/v1/tenants/{id}` | Get tenant details |
+| `PUT` | `/api/v1/tenants/{id}` | Update tenant |
+| `DELETE` | `/api/v1/tenants/{id}` | Remove tenant |
 
 ---
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -83,24 +83,36 @@ func NewRouterWithDB(tm *tenant.Manager, cfg *config.Config, database *db.DB) ht
 	})
 
 	// Register TigerTMS HTTP handlers for tenants with tigertms PMS protocol
-	for _, tc := range cfg.Tenants {
-		if tc.PMS.Protocol == "tigertms" {
-			// Create a TigerTMS adapter (host/port are not used for HTTP server, pass 0)
-			adapter, err := pms.NewAdapter("tigertms", "", 0, tigertms.WithAuthToken(tc.PMS.AuthToken))
-			if err != nil {
-				log.Error().Err(err).Str("tenant", tc.ID).Msg("Failed to create TigerTMS adapter for API router")
-				continue
-			}
-			tigerAdapter, ok := adapter.(*tigertms.Adapter)
-			if !ok {
-				log.Error().Str("tenant", tc.ID).Msg("TigerTMS adapter is wrong type")
-				continue
-			}
-			handler := tigertms.NewHandler(tigerAdapter)
-			// Store the chi.Router (which implements http.Handler), not the Handler wrapper
-			s.tigertmsHandlers[tc.ID] = handler.Routes()
+	// Load tenants from database to register their HTTP handlers
+	if database != nil {
+		tenants, err := database.ListTenants(r.Context())
+		if err == nil {
+			for _, t := range tenants {
+				if !t.Enabled {
+					continue
+				}
+				protocol, _ := t.PMSConfig["protocol"].(string)
+				if protocol == "tigertms" {
+					authToken, _ := t.PMSConfig["auth_token"].(string)
+					pathPrefix, _ := t.PMSConfig["path_prefix"].(string)
+					// Create a TigerTMS adapter (host/port are not used for HTTP server, pass 0)
+					adapter, err := pms.NewAdapter("tigertms", "", 0, tigertms.WithAuthToken(authToken))
+					if err != nil {
+						log.Error().Err(err).Str("tenant", t.ID).Msg("Failed to create TigerTMS adapter for API router")
+						continue
+					}
+					tigerAdapter, ok := adapter.(*tigertms.Adapter)
+					if !ok {
+						log.Error().Str("tenant", t.ID).Msg("TigerTMS adapter is wrong type")
+						continue
+					}
+					handler := tigertms.NewHandler(tigerAdapter)
+					// Store the chi.Router (which implements http.Handler), not the Handler wrapper
+					s.tigertmsHandlers[t.ID] = handler.Routes()
 
-			log.Info().Str("tenant", tc.ID).Str("path_prefix", tc.PMS.PathPrefix).Msg("TigerTMS HTTP handler registered")
+					log.Info().Str("tenant", t.ID).Str("path_prefix", pathPrefix).Msg("TigerTMS HTTP handler registered")
+				}
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,8 @@ import (
 type Config struct {
 	Server   ServerConfig   `yaml:"server"`
 	Database DatabaseConfig `yaml:"database"`
-	Tenants  []TenantConfig `yaml:"tenants"`
+	Crypto   CryptoConfig   `yaml:"crypto"`
+	Logging  LoggingConfig  `yaml:"logging"`
 }
 
 // ServerConfig holds HTTP server settings
@@ -29,93 +30,15 @@ type DatabaseConfig struct {
 	SSLMode  string `yaml:"ssl_mode"`
 }
 
-// TenantConfig holds per-tenant settings
-type TenantConfig struct {
-	ID         string    `yaml:"id"`
-	Name       string    `yaml:"name"`
-	PMS        PMSConfig `yaml:"pms"`
-	PBX        PBXConfig `yaml:"pbx"`
-	Cloud      CloudConfig `yaml:"cloud"`
-	RoomPrefix string    `yaml:"room_prefix"`
-	// Timezone for wake-up calls and event timestamps (e.g., "America/New_York")
-	Timezone string `yaml:"timezone"`
-	// Region for geo-routing and compliance (e.g., "us-east", "eu-west")
-	Region string `yaml:"region"`
-	// Enabled allows disabling a tenant without removing config
-	Enabled *bool `yaml:"enabled,omitempty"`
+// CryptoConfig holds encryption settings
+type CryptoConfig struct {
+	MasterKey string `yaml:"master_key"`
 }
 
-// CloudConfig holds WebSocket bridge settings for cloud platform integration
-type CloudConfig struct {
-	// Enabled enables WebSocket forwarding to cloud platform
-	Enabled bool `yaml:"enabled"`
-	// URL is the WebSocket endpoint (wss://...)
-	URL string `yaml:"url"`
-	// AuthToken is the bearer token for authentication
-	AuthToken string `yaml:"auth_token,omitempty"`
-	// ReconnectBaseDelay is the base delay for exponential backoff reconnection
-	ReconnectBaseDelay string `yaml:"reconnect_base_delay,omitempty"`
-	// ReconnectMaxDelay is the maximum delay cap for exponential backoff
-	ReconnectMaxDelay string `yaml:"reconnect_max_delay,omitempty"`
-}
-
-// PMSConfig holds PMS connection settings
-type PMSConfig struct {
-	Protocol string `yaml:"protocol"` // "mitel", "fias", or "tigertms"
-	Host     string `yaml:"host"`
-	Port     int    `yaml:"port"`
-	// Optional serial settings for Mitel
-	SerialPort string `yaml:"serial_port,omitempty"`
-	BaudRate   int    `yaml:"baud_rate,omitempty"`
-	// TigerTMS-specific settings
-	// PathPrefix is the URL path prefix for this tenant's TigerTMS endpoints
-	// e.g., "/tigertms/hotel-gamma"
-	PathPrefix string `yaml:"path_prefix,omitempty"`
-	// AuthToken is the bearer token for TigerTMS authentication
-	AuthToken string `yaml:"auth_token,omitempty"`
-
-	// Socket-binding mode: the integration service binds a local TCP socket
-	// and the PMS connects to this socket. Use ListenHost/ListenPort instead
-	// of Host/Port. If AllowedPMSIPs is non-empty, only connections from
-	// these IPs will be accepted.
-	ListenHost      string   `yaml:"listen_host,omitempty"`
-	ListenPort      int      `yaml:"listen_port,omitempty"`
-	AllowedPMSIPs   []string `yaml:"allowed_pms_ips,omitempty"`
-}
-
-// PBXConfig holds PBX provider settings
-// The Type field determines which provider implementation is used.
-type PBXConfig struct {
-	// Type identifies the PBX backend: "bicom" (default), "zultys", "freeswitch", etc.
-	Type string `yaml:"type"`
-
-	// ==========================================================================
-	// Bicom/Asterisk-specific settings
-	// ==========================================================================
-
-	// ARI settings (for Asterisk-based PBXs like Bicom)
-	ARIURL   string `yaml:"ari_url"`
-	ARIWSUrl string `yaml:"ari_ws_url"`
-	ARIUser  string `yaml:"ari_user"`
-	ARIPass  string `yaml:"ari_pass"`
-	AppName  string `yaml:"app_name"`
-
-	// Bicom REST API settings (for extension/voicemail management)
-	APIURL   string `yaml:"api_url"`   // e.g., "https://pbx.example.com"
-	APIKey   string `yaml:"api_key"`   // API key from Admin Settings
-	TenantID string `yaml:"tenant_id"` // Server/tenant ID
-
-	// ==========================================================================
-	// Zultys-specific settings
-	// ==========================================================================
-
-	// Auth settings for session-based authentication
-	AuthURL  string `yaml:"auth_url"` // Login endpoint, e.g., "/api/auth/login"
-	Username string `yaml:"username"` // Username for session auth
-	Password string `yaml:"password"` // Password for session auth
-
-	// Webhook settings for inbound PBX events
-	WebhookSecret string `yaml:"webhook_secret"` // Secret for validating inbound webhooks
+// LoggingConfig holds logging settings
+type LoggingConfig struct {
+	Level  string `yaml:"level"`
+	Format string `yaml:"format"`
 }
 
 // DSN returns the PostgreSQL connection string
@@ -155,6 +78,12 @@ func Load() (*Config, error) {
 	}
 	if cfg.Database.SSLMode == "" {
 		cfg.Database.SSLMode = "disable"
+	}
+	if cfg.Logging.Level == "" {
+		cfg.Logging.Level = "info"
+	}
+	if cfg.Logging.Format == "" {
+		cfg.Logging.Format = "json"
 	}
 
 	return &cfg, nil

--- a/internal/tenant/manager.go
+++ b/internal/tenant/manager.go
@@ -23,30 +23,135 @@ import (
 
 // Manager manages all tenant instances
 type Manager struct {
-	cfg      *config.Config
 	database *db.DB
 	tenants  map[string]*Tenant
 	mu       sync.RWMutex
 }
 
 // NewManager creates a new tenant manager
-func NewManager(cfg *config.Config, database *db.DB) (*Manager, error) {
+func NewManager(database *db.DB) (*Manager, error) {
 	m := &Manager{
-		cfg:      cfg,
 		database: database,
 		tenants:  make(map[string]*Tenant),
 	}
 
-	// Initialize tenants from config
-	for _, tc := range cfg.Tenants {
-		t, err := NewTenant(tc, database)
-		if err != nil {
-			return nil, err
-		}
-		m.tenants[tc.ID] = t
+	// If no database, start with empty tenant map
+	if database == nil {
+		return m, nil
 	}
 
 	return m, nil
+}
+
+// LoadFromDB loads and starts all enabled tenants from the database
+func (m *Manager) LoadFromDB(ctx context.Context) error {
+	if m.database == nil {
+		log.Warn().Msg("No database configured, cannot load tenants from DB")
+		return nil
+	}
+
+	tenants, err := m.database.ListTenants(ctx)
+	if err != nil {
+		return fmt.Errorf("listing tenants from database: %w", err)
+	}
+
+	for _, t := range tenants {
+		if !t.Enabled {
+			continue
+		}
+		// Convert db.Tenant to config.TenantConfig
+		tc := m.dbTenantToConfig(t)
+		tenant, err := NewTenant(tc, m.database)
+		if err != nil {
+			log.Error().Err(err).Str("tenant", t.ID).Msg("Failed to create tenant")
+			continue
+		}
+		if err := tenant.Start(ctx); err != nil {
+			log.Error().Err(err).Str("tenant", t.ID).Msg("Failed to start tenant")
+			continue
+		}
+		m.tenants[t.ID] = tenant
+		log.Info().Str("tenant", t.ID).Str("name", t.Name).Msg("Tenant loaded from database")
+	}
+
+	return nil
+}
+
+// dbTenantToConfig converts a database tenant row to a TenantConfig
+func (m *Manager) dbTenantToConfig(t db.Tenant) config.TenantConfig {
+	return config.TenantConfig{
+		ID:     t.ID,
+		Name:   t.Name,
+		PMS:    pmsConfigFromMap(t.PMSConfig),
+		PBX:    pbxConfigFromMap(t.PBXConfig),
+		Settings: t.Settings,
+	}
+}
+
+// pmsConfigFromMap converts a map to PMSConfig
+func pmsConfigFromMap(m map[string]interface{}) config.PMSConfig {
+	cfg := config.PMSConfig{}
+	if v, ok := m["protocol"].(string); ok {
+		cfg.Protocol = v
+	}
+	if v, ok := m["host"].(string); ok {
+		cfg.Host = v
+	}
+	if v, ok := m["port"].(float64); ok {
+		cfg.Port = int(v)
+	}
+	if v, ok := m["auth_token"].(string); ok {
+		cfg.AuthToken = v
+	}
+	if v, ok := m["path_prefix"].(string); ok {
+		cfg.PathPrefix = v
+	}
+	return cfg
+}
+
+// pbxConfigFromMap converts a map to PBXConfig
+func pbxConfigFromMap(m map[string]interface{}) config.PBXConfig {
+	cfg := config.PBXConfig{}
+	if v, ok := m["type"].(string); ok {
+		cfg.Type = v
+	}
+	if v, ok := m["ari_url"].(string); ok {
+		cfg.ARIURL = v
+	}
+	if v, ok := m["ari_ws_url"].(string); ok {
+		cfg.ARIWSUrl = v
+	}
+	if v, ok := m["ari_user"].(string); ok {
+		cfg.ARIUser = v
+	}
+	if v, ok := m["ari_pass"].(string); ok {
+		cfg.ARIPass = v
+	}
+	if v, ok := m["app_name"].(string); ok {
+		cfg.AppName = v
+	}
+	if v, ok := m["api_url"].(string); ok {
+		cfg.APIURL = v
+	}
+	if v, ok := m["api_key"].(string); ok {
+		cfg.APIKey = v
+	}
+	if v, ok := m["tenant_id"].(string); ok {
+		cfg.TenantID = v
+	}
+	if v, ok := m["auth_url"].(string); ok {
+		cfg.AuthURL = v
+	}
+	if v, ok := m["username"].(string); ok {
+		cfg.Username = v
+	}
+	if v, ok := m["password"].(string); ok {
+		cfg.Password = v
+	}
+	if v, ok := m["webhook_secret"].(string); ok {
+		cfg.WebhookSecret = v
+	}
+	return cfg
 }
 
 // StartAll starts all tenant services
@@ -94,75 +199,84 @@ func (m *Manager) List() []string {
 	return ids
 }
 
-// Reload updates tenant configurations without full restart
-// - Stops tenants that were removed from config
-// - Starts new tenants added to config
+// ReloadFromDB reloads tenants from the database
+// - Stops tenants that were removed from DB
+// - Starts new tenants added to DB
 // - Updates settings for existing tenants (reconnects if needed)
-func (m *Manager) Reload(newCfg *config.Config) error {
+func (m *Manager) ReloadFromDB(ctx context.Context) error {
+	if m.database == nil {
+		return fmt.Errorf("no database configured")
+	}
+
+	tenants, err := m.database.ListTenants(ctx)
+	if err != nil {
+		return fmt.Errorf("listing tenants from database: %w", err)
+	}
+
+	// Build set of new tenant IDs
+	newTenantIDs := make(map[string]bool)
+	for _, t := range tenants {
+		if t.Enabled {
+			newTenantIDs[t.ID] = true
+		}
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Build set of new tenant IDs
-	newTenantIDs := make(map[string]config.TenantConfig)
-	for _, tc := range newCfg.Tenants {
-		// Skip disabled tenants
-		if tc.Enabled != nil && !*tc.Enabled {
-			continue
-		}
-		newTenantIDs[tc.ID] = tc
-	}
-
-	// Stop and remove tenants that no longer exist in config
+	// Stop and remove tenants that no longer exist in DB
 	for id, t := range m.tenants {
-		if _, exists := newTenantIDs[id]; !exists {
-			log.Info().Str("tenant", id).Msg("Tenant removed from config, stopping")
+		if !newTenantIDs[id] {
+			log.Info().Str("tenant", id).Msg("Tenant removed from DB, stopping")
 			t.Stop()
 			delete(m.tenants, id)
 		}
 	}
 
 	// Add or update tenants
-	ctx := context.Background()
-	for id, tc := range newTenantIDs {
-		if existing, exists := m.tenants[id]; exists {
+	for _, t := range tenants {
+		if !t.Enabled {
+			continue
+		}
+		tc := m.dbTenantToConfig(t)
+		if existing, exists := m.tenants[t.ID]; exists {
 			// Tenant exists - check if config changed
 			if existing.cfg.PMS.Host != tc.PMS.Host || existing.cfg.PMS.Port != tc.PMS.Port {
 				// PMS config changed - restart tenant
-				log.Info().Str("tenant", id).Msg("PMS config changed, reconnecting")
+				log.Info().Str("tenant", t.ID).Msg("PMS config changed, reconnecting")
 				existing.Stop()
 				newTenant, err := NewTenant(tc, m.database)
 				if err != nil {
-					log.Error().Err(err).Str("tenant", id).Msg("Failed to recreate tenant")
+					log.Error().Err(err).Str("tenant", t.ID).Msg("Failed to recreate tenant")
 					continue
 				}
 				if err := newTenant.Start(ctx); err != nil {
-					log.Error().Err(err).Str("tenant", id).Msg("Failed to restart tenant")
+					log.Error().Err(err).Str("tenant", t.ID).Msg("Failed to restart tenant")
 					continue
 				}
-				m.tenants[id] = newTenant
+				m.tenants[t.ID] = newTenant
 			} else {
 				// Just update config fields that don't require restart
 				existing.Name = tc.Name
 				existing.cfg = tc
-				log.Debug().Str("tenant", id).Msg("Tenant config updated")
+				log.Debug().Str("tenant", t.ID).Msg("Tenant config updated")
 			}
 		} else {
 			// New tenant - create and start
-			log.Info().Str("tenant", id).Msg("New tenant in config, starting")
+			log.Info().Str("tenant", t.ID).Msg("New tenant in DB, starting")
 			newTenant, err := NewTenant(tc, m.database)
 			if err != nil {
-				log.Error().Err(err).Str("tenant", id).Msg("Failed to create new tenant")
+				log.Error().Err(err).Str("tenant", t.ID).Msg("Failed to create new tenant")
 				continue
 			}
 			if err := newTenant.Start(ctx); err != nil {
-				log.Error().Err(err).Str("tenant", id).Msg("Failed to start new tenant")
+				log.Error().Err(err).Str("tenant", t.ID).Msg("Failed to start new tenant")
 				continue
 			}
-			m.tenants[id] = newTenant
+			m.tenants[t.ID] = newTenant
 		}
 	}
 
-	m.cfg = newCfg
 	return nil
 }
 


### PR DESCRIPTION
## Summary

TOP-39: Remove all tenant/site/client configuration from config.yaml, transitioning to a DB-first architecture.

**Changes:**
- `config/example.yaml`: Removed all `tenants:` sections, added `crypto.master_key` and `logging` config blocks
- `internal/config/config.go`: Removed `TenantConfig` struct and `Tenants[]` field. Added `CryptoConfig` and `LoggingConfig` structs
- `internal/tenant/manager.go`: Config-driven loading replaced with DB-based loading via `LoadFromDB()`. `Reload()` replaced with `ReloadFromDB()`
- `cmd/bicom-hospitality/main.go`: Removed SIGHUP handler entirely. Simplified startup: load config → connect DB → load tenants from DB → start manager
- `internal/api/api.go`: TigerTMS handler registration now loads from DB instead of `cfg.Tenants`
- `docs/architecture.md`: Updated to document DB-first architecture with Admin API for tenant management

**Verification:**
- Server starts without any `tenants` key in config.yaml
- All site/client/system data comes from Postgres
- Admin API is the only way to manage site configuration

Closes TOP-39
