### PR TITLE
fix: resolve build errors and import issues

### DIFF
--- a/cmd/site-connector/main.go
+++ b/cmd/site-connector/main.go
@@ -36,10 +36,10 @@ import (
 
 	"github.com/sagostin/pbx-hospitality/internal/config"
 	"github.com/sagostin/pbx-hospitality/internal/pms"
-	// Import listener sub-packages to trigger their init() registrations.
-	// Each listener package registers itself with pms.ListenerRegistry on import.
-	_ "github.com/sagostin/pbx-hospitality/internal/pms/listener/fias"
-	_ "github.com/sagostin/pbx-hospitality/internal/pms/listener/mitel"
+	// Import listener package to trigger its init() registrations.
+	// The listener package registers both "fias" and "mitel" protocols
+	// with pms.ListenerRegistry on import.
+	_ "github.com/sagostin/pbx-hospitality/internal/pms/listener"
 )
 
 func main() {

--- a/internal/api/admin_tenants.go
+++ b/internal/api/admin_tenants.go
@@ -8,9 +8,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog/log"
 
-	"github.com/sagostin/pbx-hospitality/internal/config"
 	"github.com/sagostin/pbx-hospitality/internal/db"
-	"github.com/sagostin/pbx-hospitality/internal/tenant"
 )
 
 type AdminServer struct {
@@ -166,7 +164,7 @@ func (s *AdminServer) createTenant(c *fiber.Ctx) error {
 		return writeError(c, "failed to create tenant", "INTERNAL_ERROR", fiber.StatusInternalServerError)
 	}
 
-	if err := s.tm.ReloadFromDB(); err != nil {
+	if err := s.tm.ReloadFromDB(c.Context()); err != nil {
 		log.Warn().Err(err).Str("tenant", req.ID).Msg("Failed to reload tenant manager after create")
 	}
 
@@ -232,7 +230,7 @@ func (s *AdminServer) updateTenant(c *fiber.Ctx) error {
 		return writeError(c, "failed to update tenant", "INTERNAL_ERROR", fiber.StatusInternalServerError)
 	}
 
-	if err := s.tm.ReloadFromDB(); err != nil {
+	if err := s.tm.ReloadFromDB(c.Context()); err != nil {
 		log.Warn().Err(err).Str("tenant", id).Msg("Failed to reload tenant manager after update")
 	}
 
@@ -278,7 +276,7 @@ func (s *AdminServer) importTenants(c *fiber.Ctx) error {
 		return writeError(c, "database not configured", "DB_NOT_CONFIGURED", fiber.StatusServiceUnavailable)
 	}
 
-	body, err := io.ReadAll(c.Request().Body)
+	body, err := io.ReadAll(c.Request().BodyStream())
 	if err != nil {
 		return writeError(c, "failed to read request body", "INVALID_BODY", fiber.StatusBadRequest)
 	}
@@ -335,7 +333,7 @@ func (s *AdminServer) importTenants(c *fiber.Ctx) error {
 		created++
 	}
 
-	if err := s.tm.ReloadFromDB(); err != nil {
+	if err := s.tm.ReloadFromDB(c.Context()); err != nil {
 		log.Warn().Err(err).Msg("Failed to reload tenant manager after import")
 	}
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
@@ -111,7 +110,7 @@ func NewRouterWithDB(tm *tenant.Manager, cfg *config.Config, database *db.DB) ht
 
 	app.Post("/tigertms/:tenant/API/*", s.handleTigerTMS)
 
-	return app
+	return adaptor.FiberApp(app)
 }
 
 func (s *Server) health(c *fiber.Ctx) error {
@@ -425,7 +424,11 @@ func (s *Server) handlePBXWebhook(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).SendString("webhook not supported for this PBX type")
 	}
 
-	if err := webhookProvider.HandleWebhook(c.Request()); err != nil {
+	freshReq, err := adaptor.ConvertRequest(c, false)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).SendString("failed to process request")
+	}
+	if err := webhookProvider.HandleWebhook(freshReq); err != nil {
 		log.Error().Err(err).Str("tenant", tenantID).Msg("Failed to process PBX webhook")
 		return c.Status(fiber.StatusBadRequest).SendString("webhook processing failed")
 	}
@@ -449,6 +452,7 @@ func (s *Server) handleTigerTMS(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusNotFound).SendString("tenant not found")
 	}
 
-	targetApp.Handler()(c.FiberContext())
+	adaptor.CopyContextToFiberContext(c.Context(), c.Context())
+	targetApp.Handler()(c.Context())
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,43 @@ type LoggingConfig struct {
 	Format string `yaml:"format"`
 }
 
+// PMSConfig holds PMS connection settings
+type PMSConfig struct {
+	Protocol  string `yaml:"protocol"`
+	Host     string `yaml:"host"`
+	Port     int    `yaml:"port"`
+	AuthToken string `yaml:"auth_token"`
+	PathPrefix string `yaml:"path_prefix"`
+}
+
+// PBXConfig holds PBX connection settings
+type PBXConfig struct {
+	Type      string `yaml:"type"`
+	ARIURL    string `yaml:"ari_url"`
+	ARIWSUrl  string `yaml:"ari_ws_url"`
+	ARIUser   string `yaml:"ari_user"`
+	ARIPass   string `yaml:"ari_pass"`
+	AppName   string `yaml:"app_name"`
+	APIURL    string `yaml:"api_url"`
+	APIKey    string `yaml:"api_key"`
+	TenantID  string `yaml:"tenant_id"`
+	AuthURL   string `yaml:"auth_url"`
+	Username  string `yaml:"username"`
+	Password  string `yaml:"password"`
+	WebhookSecret string `yaml:"webhook_secret"`
+}
+
+// TenantConfig holds per-tenant configuration
+type TenantConfig struct {
+	ID         string     `yaml:"id"`
+	Name       string     `yaml:"name"`
+	PMS        PMSConfig  `yaml:"pms"`
+	PBX        PBXConfig  `yaml:"pbx"`
+	RoomPrefix string     `yaml:"room_prefix"`
+	Timezone   string     `yaml:"timezone"`
+	Settings   map[string]interface{} `yaml:"settings"`
+}
+
 // DSN returns the PostgreSQL connection string
 func (d *DatabaseConfig) DSN() string {
 	return fmt.Sprintf(

--- a/internal/pms/listener/fias_server.go
+++ b/internal/pms/listener/fias_server.go
@@ -31,10 +31,10 @@ func init() {
 	pms.RegisterListener("fias", NewFiasListener)
 }
 
-// Listener implements a TCP server that listens for incoming FIAS PMS connections.
+// FiasListener implements a TCP server that listens for incoming FIAS PMS connections.
 // Each connection is handled independently, parsing pipe-delimited records and
 // converting them to PMS events for downstream processing.
-type Listener struct {
+type FiasListener struct {
 	host    string
 	port    int
 	events  chan pms.Event
@@ -46,18 +46,9 @@ type Listener struct {
 	closed  bool
 }
 
-// NewListener creates a new FIAS PMS Listener TCP server.
-func NewListener(host string, port int) *Listener {
-	return &Listener{
-		host:   host,
-		port:   port,
-		events: make(chan pms.Event, 100),
-	}
-}
-
-// NewFiasListener is the factory function registered with the PMS listener registry.
+// NewFiasListener creates a new FIAS PMS Listener TCP server.
 func NewFiasListener(cfg pms.ListenerConfig, events chan pms.Event) (pms.Listener, error) {
-	l := &Listener{
+	l := &FiasListener{
 		host:    cfg.ListenHost,
 		port:    cfg.ListenPort,
 		events:  events,
@@ -69,13 +60,27 @@ func NewFiasListener(cfg pms.ListenerConfig, events chan pms.Event) (pms.Listene
 	return l, nil
 }
 
+// NewFiasListenerWithDefaultPort is a test helper that creates a listener with a default port
+func NewFiasListenerWithDefaultPort(host string, port int) *FiasListener {
+	events := make(chan pms.Event, 100)
+	l := &FiasListener{
+		host:   host,
+		port:   port,
+		events: events,
+	}
+	if l.port == 0 {
+		l.port = FiasDefaultPort
+	}
+	return l
+}
+
 // Events returns the channel of parsed PMS events from all connections.
-func (l *Listener) Events() <-chan pms.Event {
+func (l *FiasListener) Events() <-chan pms.Event {
 	return l.events
 }
 
 // isAllowed checks if the remote IP is allowed to connect.
-func (l *Listener) isAllowed(remoteIP string) bool {
+func (l *FiasListener) isAllowed(remoteIP string) bool {
 	if len(l.allowed) == 0 {
 		return true
 	}
@@ -89,7 +94,7 @@ func (l *Listener) isAllowed(remoteIP string) bool {
 
 // Listen starts the TCP server and accepts incoming connections.
 // It blocks until the context is cancelled or an error occurs.
-func (l *Listener) Listen(ctx context.Context) error {
+func (l *FiasListener) Listen(ctx context.Context) error {
 	l.mu.Lock()
 	if l.closed {
 		l.mu.Unlock()
@@ -111,7 +116,7 @@ func (l *Listener) Listen(ctx context.Context) error {
 	log.Info().
 		Str("host", l.host).
 		Int("port", l.port).
-		Msg("FIAS PMS Listener started")
+		Msg("FIAS PMS FiasListener started")
 
 	// Accept loop
 	for {
@@ -133,7 +138,7 @@ func (l *Listener) Listen(ctx context.Context) error {
 				// Deadline hit, check context and continue
 				continue
 			}
-			log.Error().Err(err).Msg("Accept error on FIAS PMS Listener")
+			log.Error().Err(err).Msg("Accept error on FIAS PMS FiasListener")
 			continue
 		}
 
@@ -148,7 +153,7 @@ func (l *Listener) Listen(ctx context.Context) error {
 
 // handleConnection processes a single FIAS PMS TCP connection.
 // It reads line-delimited records, handles link handshake, and emits events.
-func (l *Listener) handleConnection(ctx context.Context, conn net.Conn) {
+func (l *FiasListener) handleConnection(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 
 	remoteAddr := conn.RemoteAddr().String()
@@ -250,7 +255,7 @@ func (l *Listener) handleConnection(ctx context.Context, conn net.Conn) {
 
 // handleLinkRecord processes LR/LS/LA/LE records for a connection.
 // Returns the updated list of linked records for this connection.
-func (l *Listener) handleLinkRecord(line string, conn net.Conn, linkedRecords []string) []string {
+func (l *FiasListener) handleLinkRecord(line string, conn net.Conn, linkedRecords []string) []string {
 	fields := strings.Split(line, "|")
 	if len(fields) == 0 {
 		return linkedRecords
@@ -291,7 +296,7 @@ func (l *Listener) handleLinkRecord(line string, conn net.Conn, linkedRecords []
 }
 
 // Close stops the listener and closes all active connections.
-func (l *Listener) Close() error {
+func (l *FiasListener) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -317,17 +322,17 @@ func (l *Listener) Close() error {
 	log.Info().
 		Str("host", l.host).
 		Int("port", l.port).
-		Msg("FIAS PMS Listener stopped")
+		Msg("FIAS PMS FiasListener stopped")
 
 	return nil
 }
 
 // Host returns the listen address.
-func (l *Listener) Host() string {
+func (l *FiasListener) Host() string {
 	return l.host
 }
 
 // Port returns the listen port.
-func (l *Listener) Port() int {
+func (l *FiasListener) Port() int {
 	return l.port
 }

--- a/internal/pms/listener/fias_server_test.go
+++ b/internal/pms/listener/fias_server_test.go
@@ -9,16 +9,49 @@ import (
 	"time"
 
 	"github.com/sagostin/pbx-hospitality/internal/pms"
-	"github.com/sagostin/pbx-hospitality/internal/pms/fias"
 )
 
 func TestFiasListenerDefaults(t *testing.T) {
-	l := NewListener("localhost", FiasDefaultPort)
+	events := make(chan pms.Event, 100)
+	l, err := NewFiasListener(pms.ListenerConfig{ListenHost: "localhost", ListenPort: FiasDefaultPort}, events)
+	if err != nil {
+		t.Fatalf("NewFiasListener() error = %v", err)
+	}
 	if l.Host() != "localhost" {
 		t.Errorf("Host() = %q, want %q", l.Host(), "localhost")
 	}
 	if l.Port() != FiasDefaultPort {
 		t.Errorf("Port() = %d, want %d", l.Port(), FiasDefaultPort)
+	}
+}
+
+func TestFiasListenerIsAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		remoteIP  string
+		allowedIPs []string
+		want      bool
+	}{
+		{"empty allowlist", "192.168.1.1", nil, true},
+		{"empty allowlist exact", "192.168.1.1", []string{}, true},
+		{"IP in allowlist", "192.168.1.1", []string{"192.168.1.1"}, true},
+		{"IP not in allowlist", "192.168.1.1", []string{"192.168.1.2"}, false},
+		{"multiple IPs, first match", "192.168.1.1", []string{"192.168.1.1", "192.168.1.100"}, true},
+		{"multiple IPs, second match", "192.168.1.1", []string{"192.168.1.2", "192.168.1.1"}, true},
+		{"multiple IPs, no match", "192.168.1.1", []string{"192.168.1.2", "192.168.1.3"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := make(chan pms.Event, 100)
+			l, err := NewFiasListener(pms.ListenerConfig{ListenHost: "localhost", ListenPort: 5000, AllowedPMSIPs: tt.allowedIPs}, events)
+			if err != nil {
+				t.Fatalf("NewFiasListener() error = %v", err)
+			}
+			if got := l.isAllowed(tt.remoteIP); got != tt.want {
+				t.Errorf("isAllowed(%q) = %v, want %v", tt.remoteIP, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -92,7 +125,7 @@ func TestFiasIsAllowed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := NewListener("localhost", 5000)
+			l := newTestFiasListener("localhost", 5000)
 			l.allowed = tt.allowedIPs
 			if got := l.isAllowed(tt.remoteIP); got != tt.want {
 				t.Errorf("isAllowed(%q) = %v, want %v", tt.remoteIP, got, tt.want)

--- a/internal/pms/listener/listener_test_helpers.go
+++ b/internal/pms/listener/listener_test_helpers.go
@@ -1,0 +1,29 @@
+package listener
+
+import "github.com/sagostin/pbx-hospitality/internal/pms"
+
+func newTestFiasListener(host string, port int) *FiasListener {
+	events := make(chan pms.Event, 100)
+	l := &FiasListener{
+		host:   host,
+		port:   port,
+		events: events,
+	}
+	if l.port == 0 {
+		l.port = FiasDefaultPort
+	}
+	return l
+}
+
+func newTestMitelListener(host string, port int) *MitelListener {
+	events := make(chan pms.Event, 100)
+	l := &MitelListener{
+		host:   host,
+		port:   port,
+		events: events,
+	}
+	if l.port == 0 {
+		l.port = DefaultPort
+	}
+	return l
+}

--- a/internal/pms/listener/mitel_server.go
+++ b/internal/pms/listener/mitel_server.go
@@ -33,10 +33,10 @@ func init() {
 	pms.RegisterListener("mitel", NewMitelListener)
 }
 
-// Listener implements a TCP server that listens for incoming Mitel PMS connections.
+// MitelListener implements a TCP server that listens for incoming Mitel PMS connections.
 // Each connection is handled independently, parsing STX/ETX framed messages and
 // converting them to PMS events for downstream processing.
-type Listener struct {
+type MitelListener struct {
 	host    string
 	port    int
 	events  chan pms.Event
@@ -48,18 +48,9 @@ type Listener struct {
 	closed  bool
 }
 
-// NewListener creates a new PMS Listener TCP server.
-func NewListener(host string, port int) *Listener {
-	return &Listener{
-		host:   host,
-		port:   port,
-		events: make(chan pms.Event, 100),
-	}
-}
-
 // NewMitelListener is the factory function registered with the PMS listener registry.
 func NewMitelListener(cfg pms.ListenerConfig, events chan pms.Event) (pms.Listener, error) {
-	l := &Listener{
+	l := &MitelListener{
 		host:    cfg.ListenHost,
 		port:    cfg.ListenPort,
 		events:  events,
@@ -71,13 +62,27 @@ func NewMitelListener(cfg pms.ListenerConfig, events chan pms.Event) (pms.Listen
 	return l, nil
 }
 
+// NewMitelListenerWithDefaults is a test helper that creates a listener with default port
+func NewMitelListenerWithDefaults(host string, port int) *MitelListener {
+	events := make(chan pms.Event, 100)
+	l := &MitelListener{
+		host:   host,
+		port:   port,
+		events: events,
+	}
+	if l.port == 0 {
+		l.port = DefaultPort
+	}
+	return l
+}
+
 // Events returns the channel of parsed PMS events from all connections.
-func (l *Listener) Events() <-chan pms.Event {
+func (l *MitelListener) Events() <-chan pms.Event {
 	return l.events
 }
 
 // isAllowed checks if the remote IP is allowed to connect.
-func (l *Listener) isAllowed(remoteIP string) bool {
+func (l *MitelListener) isAllowed(remoteIP string) bool {
 	if len(l.allowed) == 0 {
 		return true
 	}
@@ -91,7 +96,7 @@ func (l *Listener) isAllowed(remoteIP string) bool {
 
 // Listen starts the TCP server and accepts incoming connections.
 // It blocks until the context is cancelled or an error occurs.
-func (l *Listener) Listen(ctx context.Context) error {
+func (l *MitelListener) Listen(ctx context.Context) error {
 	l.mu.Lock()
 	if l.closed {
 		l.mu.Unlock()
@@ -113,7 +118,7 @@ func (l *Listener) Listen(ctx context.Context) error {
 	log.Info().
 		Str("host", l.host).
 		Int("port", l.port).
-		Msg("PMS Listener started")
+		Msg("PMS MitelListener started")
 
 	// Accept loop
 	for {
@@ -135,7 +140,7 @@ func (l *Listener) Listen(ctx context.Context) error {
 				// Deadline hit, check context and continue
 				continue
 			}
-			log.Error().Err(err).Msg("Accept error on PMS Listener")
+			log.Error().Err(err).Msg("Accept error on PMS MitelListener")
 			continue
 		}
 
@@ -150,7 +155,7 @@ func (l *Listener) Listen(ctx context.Context) error {
 
 // handleConnection processes a single PMS TCP connection.
 // It reads STX/ETX framed messages, sends ACK/NAK responses, and emits events.
-func (l *Listener) handleConnection(ctx context.Context, conn net.Conn) {
+func (l *MitelListener) handleConnection(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 
 	remoteAddr := conn.RemoteAddr().String()
@@ -284,7 +289,7 @@ func (l *Listener) handleConnection(ctx context.Context, conn net.Conn) {
 
 // sendResponse sends an ACK or NAK response to the PMS.
 // Returns false if the write fails (connection should be closed).
-func (l *Listener) sendResponse(conn net.Conn, response byte, remoteAddr string) bool {
+func (l *MitelListener) sendResponse(conn net.Conn, response byte, remoteAddr string) bool {
 	conn.SetWriteDeadline(time.Now().Add(ACKTimeout))
 	if _, err := conn.Write([]byte{response}); err != nil {
 		log.Warn().
@@ -297,7 +302,7 @@ func (l *Listener) sendResponse(conn net.Conn, response byte, remoteAddr string)
 }
 
 // Close stops the listener and closes all active connections.
-func (l *Listener) Close() error {
+func (l *MitelListener) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -323,18 +328,18 @@ func (l *Listener) Close() error {
 	log.Info().
 		Str("host", l.host).
 		Int("port", l.port).
-		Msg("PMS Listener stopped")
+		Msg("PMS MitelListener stopped")
 
 	return nil
 }
 
 // Host returns the listen address.
-func (l *Listener) Host() string {
+func (l *MitelListener) Host() string {
 	return l.host
 }
 
 // Port returns the listen port.
-func (l *Listener) Port() int {
+func (l *MitelListener) Port() int {
 	return l.port
 }
 

--- a/internal/pms/listener/mitel_server_test.go
+++ b/internal/pms/listener/mitel_server_test.go
@@ -12,7 +12,11 @@ import (
 )
 
 func TestListenerDefaults(t *testing.T) {
-	l := NewListener("localhost", DefaultPort)
+	events := make(chan pms.Event, 100)
+	l, err := NewMitelListener(pms.ListenerConfig{ListenHost: "localhost", ListenPort: DefaultPort}, events)
+	if err != nil {
+		t.Fatalf("NewMitelListener() error = %v", err)
+	}
 	if l.Host() != "localhost" {
 		t.Errorf("Host() = %q, want %q", l.Host(), "localhost")
 	}
@@ -142,7 +146,7 @@ const (
 
 func TestListenerIntegration(t *testing.T) {
 	// Start listener on random port
-	ln := NewListener("localhost", 0)
+	ln := newTestMitelListener("localhost", 0)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -464,7 +468,7 @@ func TestListenerAllowedIPs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			l := NewListener("localhost", 0)
+			l := newTestMitelListener("localhost", 0)
 			l.allowed = tt.allowed
 			if got := l.isAllowed(tt.ip); got != tt.expected {
 				t.Errorf("isAllowed(%q) = %v, want %v", tt.ip, got, tt.expected)


### PR DESCRIPTION
## Summary
- Fix site-connector import paths for listener subpackages
- Rename Listener types to FiasListener/MitelListener to resolve name conflicts in same package
- Add missing TenantConfig, PMSConfig, PBXConfig types in config package
- Fix fiber API issues: unused imports, http.Handler return type, webhook request conversion
- Fix ReloadFromDB calls to pass context, use BodyStream for request body reading
- Update listener tests with new constructor patterns

## Testing
- `go build ./...` succeeds