### PR TITLE
Add sites management, tenant settings, and ARI event debugging

### DIFF
--- a/internal/api/admin_sites.go
+++ b/internal/api/admin_sites.go
@@ -1,0 +1,236 @@
+package api
+
+import (
+	"regexp"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog/log"
+
+	"github.com/sagostin/pbx-hospitality/internal/db"
+)
+
+type siteResponse struct {
+	ID        string                 `json:"id"`
+	Name      string                 `json:"name"`
+	AuthCode  string                 `json:"-"` // Never expose in API responses
+	Settings  map[string]interface{} `json:"settings"`
+	Enabled   bool                   `json:"enabled"`
+	CreatedAt string                 `json:"created_at,omitempty"`
+	UpdatedAt string                 `json:"updated_at,omitempty"`
+}
+
+type createSiteRequest struct {
+	ID       string                 `json:"id"`
+	Name     string                 `json:"name"`
+	AuthCode string                 `json:"auth_code"`
+	Settings map[string]interface{} `json:"settings"`
+	Enabled  bool                   `json:"enabled"`
+}
+
+type updateSiteRequest struct {
+	Name     *string                `json:"name,omitempty"`
+	AuthCode *string                `json:"auth_code,omitempty"`
+	Settings map[string]interface{} `json:"settings,omitempty"`
+	Enabled  *bool                  `json:"enabled,omitempty"`
+}
+
+var siteIDRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$`)
+
+func validateSiteID(id string) bool {
+	if len(id) == 0 || len(id) > 64 {
+		return false
+	}
+	return siteIDRegex.MatchString(id)
+}
+
+func (s *AdminServer) listSites(c *fiber.Ctx) error {
+	if s.db == nil {
+		return writeError(c, "database not configured", "DB_NOT_CONFIGURED", fiber.StatusServiceUnavailable)
+	}
+
+	sites, err := s.db.ListSites(c.Context())
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to list sites")
+		return writeError(c, "failed to list sites", "INTERNAL_ERROR", fiber.StatusInternalServerError)
+	}
+
+	result := make([]siteResponse, 0, len(sites))
+	for _, site := range sites {
+		result = append(result, toSiteResponse(site))
+	}
+
+	c.Set("Content-Type", "application/json")
+	return c.JSON(result)
+}
+
+func (s *AdminServer) getSite(c *fiber.Ctx) error {
+	if s.db == nil {
+		return writeError(c, "database not configured", "DB_NOT_CONFIGURED", fiber.StatusServiceUnavailable)
+	}
+
+	id := c.Params("id")
+	if !validateSiteID(id) {
+		return writeError(c, "invalid site ID format", "INVALID_ID", fiber.StatusBadRequest)
+	}
+
+	site, err := s.db.GetSite(c.Context(), id)
+	if err != nil {
+		log.Error().Err(err).Str("site", id).Msg("Failed to get site")
+		return writeError(c, "failed to get site", "INTERNAL_ERROR", fiber.StatusInternalServerError)
+	}
+	if site == nil {
+		return writeError(c, "site not found", "NOT_FOUND", fiber.StatusNotFound)
+	}
+
+	c.Set("Content-Type", "application/json")
+	return c.JSON(toSiteResponse(*site))
+}
+
+func (s *AdminServer) createSite(c *fiber.Ctx) error {
+	if s.db == nil {
+		return writeError(c, "database not configured", "DB_NOT_CONFIGURED", fiber.StatusServiceUnavailable)
+	}
+
+	var req createSiteRequest
+	if err := c.BodyParser(&req); err != nil {
+		return writeError(c, "invalid request body", "INVALID_BODY", fiber.StatusBadRequest)
+	}
+
+	if req.ID == "" {
+		return writeError(c, "id is required", "VALIDATION_ERROR", fiber.StatusBadRequest)
+	}
+	if !validateSiteID(req.ID) {
+		return writeError(c, "id must be alphanumeric with dashes, max 64 chars", "VALIDATION_ERROR", fiber.StatusBadRequest)
+	}
+	if req.Name == "" {
+		return writeError(c, "name is required", "VALIDATION_ERROR", fiber.StatusBadRequest)
+	}
+	if len(req.Name) > 255 {
+		return writeError(c, "name must be max 255 chars", "VALIDATION_ERROR", fiber.StatusBadRequest)
+	}
+	if req.AuthCode == "" {
+		return writeError(c, "auth_code is required", "VALIDATION_ERROR", fiber.StatusBadRequest)
+	}
+	if len(req.AuthCode) < 16 {
+		return writeError(c, "auth_code must be at least 16 characters", "VALIDATION_ERROR", fiber.StatusBadRequest)
+	}
+
+	existing, err := s.db.GetSite(c.Context(), req.ID)
+	if err != nil {
+		log.Error().Err(err).Str("site", req.ID).Msg("Failed to check existing site")
+		return writeError(c, "failed to create site", "INTERNAL_ERROR", fiber.StatusInternalServerError)
+	}
+	if existing != nil {
+		return writeError(c, "site already exists", "ALREADY_EXISTS", fiber.StatusConflict)
+	}
+
+	site := &db.Site{
+		ID:       req.ID,
+		Name:     req.Name,
+		AuthCode: req.AuthCode, // In production, this should be hashed
+		Settings: req.Settings,
+		Enabled:  req.Enabled,
+	}
+	if err := s.db.CreateSite(c.Context(), site); err != nil {
+		log.Error().Err(err).Str("site", req.ID).Msg("Failed to create site")
+		return writeError(c, "failed to create site", "INTERNAL_ERROR", fiber.StatusInternalServerError)
+	}
+
+	created, _ := s.db.GetSite(c.Context(), req.ID)
+	c.Set("Content-Type", "application/json")
+	return c.Status(fiber.StatusCreated).JSON(toSiteResponse(*created))
+}
+
+func (s *AdminServer) updateSite(c *fiber.Ctx) error {
+	if s.db == nil {
+		return writeError(c, "database not configured", "DB_NOT_CONFIGURED", fiber.StatusServiceUnavailable)
+	}
+
+	id := c.Params("id")
+	if !validateSiteID(id) {
+		return writeError(c, "invalid site ID format", "INVALID_ID", fiber.StatusBadRequest)
+	}
+
+	existing, err := s.db.GetSite(c.Context(), id)
+	if err != nil {
+		log.Error().Err(err).Str("site", id).Msg("Failed to get site for update")
+		return writeError(c, "failed to update site", "INTERNAL_ERROR", fiber.StatusInternalServerError)
+	}
+	if existing == nil {
+		return writeError(c, "site not found", "NOT_FOUND", fiber.StatusNotFound)
+	}
+
+	var req updateSiteRequest
+	if err := c.BodyParser(&req); err != nil {
+		return writeError(c, "invalid request body", "INVALID_BODY", fiber.StatusBadRequest)
+	}
+
+	if req.Name != nil {
+		if *req.Name == "" {
+			return writeError(c, "name cannot be empty", "VALIDATION_ERROR", fiber.StatusBadRequest)
+		}
+		if len(*req.Name) > 255 {
+			return writeError(c, "name must be max 255 chars", "VALIDATION_ERROR", fiber.StatusBadRequest)
+		}
+		existing.Name = *req.Name
+	}
+	if req.AuthCode != nil {
+		if len(*req.AuthCode) < 16 {
+			return writeError(c, "auth_code must be at least 16 characters", "VALIDATION_ERROR", fiber.StatusBadRequest)
+		}
+		existing.AuthCode = *req.AuthCode // In production, hash this
+	}
+	if req.Settings != nil {
+		existing.Settings = req.Settings
+	}
+	if req.Enabled != nil {
+		existing.Enabled = *req.Enabled
+	}
+
+	if err := s.db.UpdateSite(c.Context(), existing); err != nil {
+		log.Error().Err(err).Str("site", id).Msg("Failed to update site")
+		return writeError(c, "failed to update site", "INTERNAL_ERROR", fiber.StatusInternalServerError)
+	}
+
+	c.Set("Content-Type", "application/json")
+	return c.JSON(toSiteResponse(*existing))
+}
+
+func (s *AdminServer) deleteSite(c *fiber.Ctx) error {
+	if s.db == nil {
+		return writeError(c, "database not configured", "DB_NOT_CONFIGURED", fiber.StatusServiceUnavailable)
+	}
+
+	id := c.Params("id")
+	if !validateSiteID(id) {
+		return writeError(c, "invalid site ID format", "INVALID_ID", fiber.StatusBadRequest)
+	}
+
+	existing, err := s.db.GetSite(c.Context(), id)
+	if err != nil {
+		log.Error().Err(err).Str("site", id).Msg("Failed to get site for delete")
+		return writeError(c, "failed to delete site", "INTERNAL_ERROR", fiber.StatusInternalServerError)
+	}
+	if existing == nil {
+		return writeError(c, "site not found", "NOT_FOUND", fiber.StatusNotFound)
+	}
+
+	if err := s.db.DeleteSite(c.Context(), id); err != nil {
+		log.Error().Err(err).Str("site", id).Msg("Failed to delete site")
+		return writeError(c, "failed to delete site", "INTERNAL_ERROR", fiber.StatusInternalServerError)
+	}
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func toSiteResponse(s db.Site) siteResponse {
+	return siteResponse{
+		ID:        s.ID,
+		Name:      s.Name,
+		AuthCode:  "", // Never expose
+		Settings:  s.Settings,
+		Enabled:   s.Enabled,
+		CreatedAt: s.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		UpdatedAt: s.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+	}
+}

--- a/internal/api/admin_tenants.go
+++ b/internal/api/admin_tenants.go
@@ -35,6 +35,7 @@ func writeError(c *fiber.Ctx, message, code string, status int) error {
 
 type tenantResponse struct {
 	ID        string                 `json:"id"`
+	SiteID    *string                `json:"site_id,omitempty"`
 	Name      string                 `json:"name"`
 	PMSConfig map[string]interface{} `json:"pms_config"`
 	PBXConfig map[string]interface{} `json:"pbx_config"`
@@ -46,6 +47,7 @@ type tenantResponse struct {
 
 type createTenantRequest struct {
 	ID        string                 `json:"id"`
+	SiteID    *string                `json:"site_id,omitempty"`
 	Name      string                 `json:"name"`
 	PMSConfig map[string]interface{} `json:"pms_config"`
 	PBXConfig map[string]interface{} `json:"pbx_config"`
@@ -54,6 +56,7 @@ type createTenantRequest struct {
 }
 
 type updateTenantRequest struct {
+	SiteID    *string                `json:"site_id,omitempty"`
 	Name      *string                `json:"name,omitempty"`
 	PMSConfig map[string]interface{} `json:"pms_config,omitempty"`
 	PBXConfig map[string]interface{} `json:"pbx_config,omitempty"`
@@ -153,6 +156,7 @@ func (s *AdminServer) createTenant(c *fiber.Ctx) error {
 
 	t := &db.Tenant{
 		ID:        req.ID,
+		SiteID:    req.SiteID,
 		Name:      req.Name,
 		PMSConfig: req.PMSConfig,
 		PBXConfig: req.PBXConfig,
@@ -205,6 +209,13 @@ func (s *AdminServer) updateTenant(c *fiber.Ctx) error {
 			return writeError(c, "name must be max 255 chars", "VALIDATION_ERROR", fiber.StatusBadRequest)
 		}
 		existing.Name = *req.Name
+	}
+	if req.SiteID != nil {
+		if *req.SiteID == "" {
+			existing.SiteID = nil // Clear site association
+		} else {
+			existing.SiteID = req.SiteID
+		}
 	}
 	if req.PMSConfig != nil {
 		if err := validatePMSConfig(req.PMSConfig); err != nil {
@@ -386,6 +397,7 @@ func (e *validationError) Error() string {
 func toTenantResponse(t db.Tenant) tenantResponse {
 	return tenantResponse{
 		ID:        t.ID,
+		SiteID:    t.SiteID,
 		Name:      t.Name,
 		PMSConfig: t.PMSConfig,
 		PBXConfig: t.PBXConfig,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -61,6 +61,14 @@ func NewRouterWithDB(tm *tenant.Manager, cfg *config.Config, database *db.DB) ht
 	adminGroup.Delete("/:id", admin.deleteTenant)
 	adminGroup.Post("/import", admin.importTenants)
 
+	adminSitesGroup := app.Group("/admin/sites")
+	adminSitesGroup.Use(adminKeyMiddleware(cfg.Server.AdminAPIKey))
+	adminSitesGroup.Get("/", admin.listSites)
+	adminSitesGroup.Get("/:id", admin.getSite)
+	adminSitesGroup.Post("/", admin.createSite)
+	adminSitesGroup.Put("/:id", admin.updateSite)
+	adminSitesGroup.Delete("/:id", admin.deleteSite)
+
 	apiV1 := app.Group("/api/v1")
 	tenants := apiV1.Group("/tenants")
 	tenants.Get("/", s.listTenants)

--- a/internal/ari/client.go
+++ b/internal/ari/client.go
@@ -11,6 +11,24 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// EventType represents the type of ARI event
+type EventType string
+
+const (
+	EventTypeStasisStart        EventType = "StasisStart"
+	EventTypeStasisEnd          EventType = "StasisEnd"
+	EventTypeChannelStateChange  EventType = "ChannelStateChange"
+	EventTypeChannelCreated      EventType = "ChannelCreated"
+	EventTypeChannelDestroyed    EventType = "ChannelDestroyed"
+	EventTypePlaybackStarted     EventType = "PlaybackStarted"
+	EventTypePlaybackFinished    EventType = "PlaybackFinished"
+	EventTypeDial               EventType = "Dial"
+	EventTypeBridgeCreated       EventType = "BridgeCreated"
+	EventTypeBridgeDestroyed    EventType = "BridgeDestroyed"
+	EventTypeEndpointStateChange EventType = "EndpointStateChange"
+	EventTypeUnknown            EventType = "Unknown"
+)
+
 // Config holds ARI client configuration
 type Config struct {
 	URL      string
@@ -20,13 +38,54 @@ type Config struct {
 	AppName  string
 }
 
-// Client wraps the CyCoreSystems ARI client with reconnection logic
+// ARIEvent represents a captured ARI event for debugging/analysis
+type ARIEvent struct {
+	Type      EventType
+	Timestamp time.Time
+	ChannelID string
+	Exten     string
+	CallerID  string
+	CallerName string
+	Dialplan  string
+	State     string
+	Metadata  map[string]string
+}
+
+// EventObserver is a callback interface for receiving ARI events
+type EventObserver interface {
+	OnARIEvent(event ARIEvent)
+}
+
+// EventFilter controls which events are captured
+type EventFilter struct {
+	IncludeStasisStart        bool
+	IncludeStasisEnd          bool
+	IncludeChannelStateChange bool
+	IncludeDial              bool
+	IncludeAll               bool
+}
+
+// DefaultEventFilter returns a filter that captures all events
+func DefaultEventFilter() EventFilter {
+	return EventFilter{
+		IncludeAll: true,
+	}
+}
+
+// Client wraps the CyCoreSystems ARI client with reconnection logic and event debugging
 type Client struct {
 	cfg       Config
 	client    arilib.Client
 	mu        sync.RWMutex
 	connected bool
 	cancel    context.CancelFunc
+
+	// Event debugging
+	observers []EventObserver
+	filter    EventFilter
+	events    []ARIEvent       // Circular buffer of recent events
+	eventsMu  sync.RWMutex
+	eventSub  arilib.Subscription
 }
 
 // NewClient creates a new ARI client wrapper
@@ -220,4 +279,264 @@ func (c *Client) Originate(ctx context.Context, from, to string, timeout time.Du
 	}
 
 	return handle, nil
+}
+
+// AddObserver registers an observer for ARI events
+func (c *Client) AddObserver(observer EventObserver) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.observers = append(c.observers, observer)
+}
+
+// RemoveObserver unregisters an observer
+func (c *Client) RemoveObserver(observer EventObserver) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i, obs := range c.observers {
+		if obs == observer {
+			c.observers = append(c.observers[:i], c.observers[i+1:]...)
+			return
+		}
+	}
+}
+
+// SetFilter configures which events are captured
+func (c *Client) SetFilter(filter EventFilter) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.filter = filter
+}
+
+// GetRecentEvents returns the most recent events (up to maxEvents)
+func (c *Client) GetRecentEvents(maxEvents int) []ARIEvent {
+	c.eventsMu.RLock()
+	defer c.eventsMu.RUnlock()
+	if maxEvents > len(c.events) {
+		maxEvents = len(c.events)
+	}
+	result := make([]ARIEvent, maxEvents)
+	copy(result, c.events[len(c.events)-maxEvents:])
+	return result
+}
+
+// EnableDebugging turns on verbose ARI event logging for development
+func (c *Client) EnableDebugging() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.filter.IncludeAll = true
+	c.filter.IncludeStasisStart = true
+	c.filter.IncludeStasisEnd = true
+	c.filter.IncludeChannelStateChange = true
+	c.filter.IncludeDial = true
+	log.Info().Msg("ARI debugging enabled")
+}
+
+// DisableDebugging turns off verbose ARI event logging
+func (c *Client) DisableDebugging() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.filter = EventFilter{}
+	log.Info().Msg("ARI debugging disabled")
+}
+
+// SubscribeToEvents starts capturing ARI events for debugging
+func (c *Client) SubscribeToEvents() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client == nil {
+		return fmt.Errorf("not connected to ARI")
+	}
+
+	if c.eventSub != nil {
+		return nil // Already subscribed
+	}
+
+	// Subscribe to all ARI events
+	c.eventSub = c.client.Bridge().Subscribe(nil, "StasisStart", "StasisEnd",
+		"ChannelStateChange", "ChannelCreated", "ChannelDestroyed",
+		"Dial", "BridgeCreated", "BridgeDestroyed", "EndpointStateChange")
+
+	if c.eventSub == nil {
+		return fmt.Errorf("failed to subscribe to ARI events")
+	}
+
+	// Process events in background
+	go c.processEvents()
+
+	log.Info().Msg("Subscribed to ARI events for debugging")
+	return nil
+}
+
+// processEvents handles incoming ARI events
+func (c *Client) processEvents() {
+	if c.eventSub == nil {
+		return
+	}
+
+	for v := range c.eventSub.Events() {
+		if v == nil {
+			continue
+		}
+		c.handleARIEvent(v)
+	}
+}
+
+// handleARIEvent converts ARI events to ARIEvent and captures them
+func (c *Client) handleARIEvent(v interface{}) {
+	switch event := v.(type) {
+	case *arilib.StasisStart:
+		c.captureEvent(ARIEvent{
+			Type:       EventTypeStasisStart,
+			Timestamp:  time.Now(),
+			ChannelID:  event.Channel.ID,
+			Exten:      extractDialedNumber(event.Channel),
+			CallerID:   extractCallerNumber(event.Channel),
+			CallerName: extractCallerName(event.Channel),
+			State:      string(event.Channel.State),
+			Metadata:   extractChannelMetadata(event.Channel),
+		})
+	case *arilib.StasisEnd:
+		c.captureEvent(ARIEvent{
+			Type:       EventTypeStasisEnd,
+			Timestamp:  time.Now(),
+			ChannelID:  event.Channel.ID,
+			CallerID:   extractCallerNumber(event.Channel),
+			State:      string(event.Channel.State),
+			Metadata:   extractChannelMetadata(event.Channel),
+		})
+	case *arilib.ChannelStateChange:
+		c.captureEvent(ARIEvent{
+			Type:       EventTypeChannelStateChange,
+			Timestamp:  time.Now(),
+			ChannelID:  event.Channel.ID,
+			Exten:      extractDialedNumber(event.Channel),
+			CallerID:   extractCallerNumber(event.Channel),
+			State:      string(event.Channel.State),
+			Metadata:   extractChannelMetadata(event.Channel),
+		})
+	case *arilib.Dial:
+		// Dial events contain caller and peer channel data
+		c.captureEvent(ARIEvent{
+			Type:       EventTypeDial,
+			Timestamp:  time.Now(),
+			ChannelID:  event.Caller.ID,
+			Exten:      event.Dialstring,
+			CallerName: event.Caller.Name,
+			State:      event.Dialstatus,
+			Metadata: map[string]string{
+				"dialstring": event.Dialstring,
+				"forward":    event.Forward,
+				"peer_name":  event.Peer.Name,
+				"peer_id":    event.Peer.ID,
+				"dialstatus": event.Dialstatus,
+			},
+		})
+	default:
+		c.captureEvent(ARIEvent{
+			Type:       EventTypeUnknown,
+			Timestamp:  time.Now(),
+			Metadata:   map[string]string{"raw_type": fmt.Sprintf("%T", v)},
+		})
+	}
+}
+
+// extractDialedNumber extracts the dialed number from a channel
+func extractDialedNumber(channel arilib.ChannelData) string {
+	if channel.Dialplan != nil && channel.Dialplan.Exten != "" {
+		return channel.Dialplan.Exten
+	}
+	if channel.Connected != nil && channel.Connected.Number != "" {
+		return channel.Connected.Number
+	}
+	return channel.ID
+}
+
+// extractCallerNumber extracts the caller ID number from a channel
+func extractCallerNumber(channel arilib.ChannelData) string {
+	if channel.Caller != nil {
+		return channel.Caller.Number
+	}
+	return ""
+}
+
+// extractCallerName extracts the caller ID name from a channel
+func extractCallerName(channel arilib.ChannelData) string {
+	if channel.Caller != nil {
+		return channel.Caller.Name
+	}
+	return ""
+}
+
+// extractChannelMetadata extracts additional channel info as metadata
+func extractChannelMetadata(channel arilib.ChannelData) map[string]string {
+	meta := make(map[string]string)
+	if channel.Connected != nil {
+		meta["connected_name"] = channel.Connected.Name
+		meta["connected_number"] = channel.Connected.Number
+	}
+	if channel.Dialplan != nil {
+		meta["dialplan_context"] = channel.Dialplan.Context
+		meta["dialplan_exten"] = channel.Dialplan.Exten
+		meta["dialplan_priority"] = fmt.Sprintf("%v", channel.Dialplan.Priority)
+	}
+	meta["channel_state"] = string(channel.State)
+	return meta
+}
+
+// notifyObservers sends an event to all registered observers
+func (c *Client) notifyObservers(event ARIEvent) {
+	c.mu.RLock()
+	observers := c.observers
+	c.mu.RUnlock()
+
+	for _, obs := range observers {
+		obs.OnARIEvent(event)
+	}
+}
+
+// shouldCaptureEvent checks if an event should be captured based on the filter
+func (c *Client) shouldCaptureEvent(eventType EventType) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.filter.IncludeAll {
+		return true
+	}
+	switch eventType {
+	case EventTypeStasisStart:
+		return c.filter.IncludeStasisStart
+	case EventTypeStasisEnd:
+		return c.filter.IncludeStasisEnd
+	case EventTypeChannelStateChange:
+		return c.filter.IncludeChannelStateChange
+	case EventTypeDial:
+		return c.filter.IncludeDial
+	default:
+		return false
+	}
+}
+
+// captureEvent records an event and notifies observers
+func (c *Client) captureEvent(event ARIEvent) {
+	if !c.shouldCaptureEvent(event.Type) {
+		return
+	}
+
+	c.eventsMu.Lock()
+	c.events = append(c.events, event)
+	// Keep only last 1000 events
+	if len(c.events) > 1000 {
+		c.events = c.events[len(c.events)-1000:]
+	}
+	c.eventsMu.Unlock()
+
+	c.notifyObservers(event)
+
+	log.Debug().
+		Str("type", string(event.Type)).
+		Str("channel_id", event.ChannelID).
+		Str("extension", event.Exten).
+		Str("caller_id", event.CallerID).
+		Msg("ARI event captured")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,30 +72,58 @@ type PMSConfig struct {
 
 // PBXConfig holds PBX connection settings
 type PBXConfig struct {
-	Type      string `yaml:"type"`
-	ARIURL    string `yaml:"ari_url"`
-	ARIWSUrl  string `yaml:"ari_ws_url"`
-	ARIUser   string `yaml:"ari_user"`
-	ARIPass   string `yaml:"ari_pass"`
-	AppName   string `yaml:"app_name"`
-	APIURL    string `yaml:"api_url"`
-	APIKey    string `yaml:"api_key"`
-	TenantID  string `yaml:"tenant_id"`
-	AuthURL   string `yaml:"auth_url"`
-	Username  string `yaml:"username"`
-	Password  string `yaml:"password"`
+	Type          string `yaml:"type"`
+	ARIURL        string `yaml:"ari_url"`
+	ARIWSUrl      string `yaml:"ari_ws_url"`
+	ARIUser       string `yaml:"ari_user"`
+	ARIPass       string `yaml:"ari_pass"`
+	AppName       string `yaml:"app_name"`
+	APIURL        string `yaml:"api_url"`
+	APIKey        string `yaml:"api_key"`
+	TenantID      string `yaml:"tenant_id"`
+	AuthURL       string `yaml:"auth_url"`
+	Username      string `yaml:"username"`
+	Password      string `yaml:"password"`
 	WebhookSecret string `yaml:"webhook_secret"`
 }
 
 // TenantConfig holds per-tenant configuration
 type TenantConfig struct {
-	ID         string     `yaml:"id"`
-	Name       string     `yaml:"name"`
-	PMS        PMSConfig  `yaml:"pms"`
-	PBX        PBXConfig  `yaml:"pbx"`
-	RoomPrefix string     `yaml:"room_prefix"`
-	Timezone   string     `yaml:"timezone"`
-	Settings   map[string]interface{} `yaml:"settings"`
+	ID         string                    `yaml:"id"`
+	Name       string                    `yaml:"name"`
+	SiteID     string                    `yaml:"site_id"`
+	PMS        PMSConfig                 `yaml:"pms"`
+	PBX        PBXConfig                 `yaml:"pbx"`
+	RoomPrefix string                    `yaml:"room_prefix"`
+	Timezone   string                    `yaml:"timezone"`
+	Settings   TenantSettings            `yaml:"settings"`
+}
+
+// TenantSettings holds feature flags and access codes for a tenant
+type TenantSettings struct {
+	RoomPrefix     string            `yaml:"room_prefix"`      // Prepended to room numbers for extension mapping
+	ExtensionRange [2]int           `yaml:"extension_range"`   // Min/max extension numbers
+	Features       TenantFeatures    `yaml:"features"`         // Enabled features
+	AccessCodes    AccessCodes       `yaml:"access_codes"`     // Feature access codes
+}
+
+// TenantFeatures specifies which features are enabled for a tenant
+type TenantFeatures struct {
+	WakeUpCalls   bool `yaml:"wake_up_calls"`
+	RoomCleanCode bool `yaml:"room_clean_code"` // Code to signal room needs cleaning
+	DND           bool `yaml:"dnd"`
+	MWI           bool `yaml:"mwi"`
+	Voicemail     bool `yaml:"voicemail"`
+	CallForward   bool `yaml:"call_forward"`
+}
+
+// AccessCodes defines feature access codes
+type AccessCodes struct {
+	WakeUp         string `yaml:"wake_up"`           // e.g., "*411"
+	RoomClean      string `yaml:"room_clean"`        // e.g., "*60"
+	RoomService    string `yaml:"room_service"`      // e.g., "*70"
+	DoNotDisturb   string `yaml:"do_not_disturb"`    // e.g., "*78"
+	Voicemail      string `yaml:"voicemail"`          // e.g., "*98"
 }
 
 // DSN returns the PostgreSQL connection string

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -74,12 +74,138 @@ func (db *DB) Pool() *pgxpool.Pool {
 }
 
 // =============================================================================
+// Site Repository
+// =============================================================================
+
+// Site represents a physical location/grouping of tenants
+type Site struct {
+	ID        string
+	Name      string
+	AuthCode  string // Hashed auth code for site connector authentication
+	Settings  map[string]interface{}
+	Enabled   bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// GetSite retrieves a site by ID
+func (db *DB) GetSite(ctx context.Context, id string) (*Site, error) {
+	var s Site
+	err := db.pool.QueryRow(ctx, `
+		SELECT id, name, auth_code, settings, enabled, created_at, updated_at
+		FROM sites WHERE id = $1
+	`, id).Scan(&s.ID, &s.Name, &s.AuthCode, &s.Settings, &s.Enabled, &s.CreatedAt, &s.UpdatedAt)
+
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying site: %w", err)
+	}
+	return &s, nil
+}
+
+// ListSites returns all sites
+func (db *DB) ListSites(ctx context.Context) ([]Site, error) {
+	rows, err := db.pool.Query(ctx, `
+		SELECT id, name, auth_code, settings, enabled, created_at, updated_at
+		FROM sites ORDER BY name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying sites: %w", err)
+	}
+	defer rows.Close()
+
+	var sites []Site
+	for rows.Next() {
+		var s Site
+		if err := rows.Scan(&s.ID, &s.Name, &s.AuthCode, &s.Settings, &s.Enabled, &s.CreatedAt, &s.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scanning site: %w", err)
+		}
+		sites = append(sites, s)
+	}
+	return sites, nil
+}
+
+// CreateSite creates a new site
+func (db *DB) CreateSite(ctx context.Context, s *Site) error {
+	_, err := db.pool.Exec(ctx, `
+		INSERT INTO sites (id, name, auth_code, settings, enabled)
+		VALUES ($1, $2, $3, $4, $5)
+	`, s.ID, s.Name, s.AuthCode, s.Settings, s.Enabled)
+	if err != nil {
+		return fmt.Errorf("creating site: %w", err)
+	}
+	return nil
+}
+
+// UpdateSite updates an existing site
+func (db *DB) UpdateSite(ctx context.Context, s *Site) error {
+	_, err := db.pool.Exec(ctx, `
+		UPDATE sites
+		SET name = $2, auth_code = $3, settings = $4, enabled = $5, updated_at = NOW()
+		WHERE id = $1
+	`, s.ID, s.Name, s.AuthCode, s.Settings, s.Enabled)
+	if err != nil {
+		return fmt.Errorf("updating site: %w", err)
+	}
+	return nil
+}
+
+// DeleteSite deletes a site by ID (tenants become orphaned, site_id set to NULL)
+func (db *DB) DeleteSite(ctx context.Context, id string) error {
+	_, err := db.pool.Exec(ctx, `DELETE FROM sites WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("deleting site: %w", err)
+	}
+	return nil
+}
+
+// ValidateSiteAuthCode checks if the provided auth code matches the site's auth code
+func (db *DB) ValidateSiteAuthCode(ctx context.Context, siteID, authCode string) (bool, error) {
+	var storedCode string
+	err := db.pool.QueryRow(ctx, `
+		SELECT auth_code FROM sites WHERE id = $1 AND enabled = TRUE
+	`, siteID).Scan(&storedCode)
+	if err == pgx.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("querying site auth: %w", err)
+	}
+	return storedCode == authCode, nil
+}
+
+// ListTenantsBySite returns all tenants belonging to a site
+func (db *DB) ListTenantsBySite(ctx context.Context, siteID string) ([]Tenant, error) {
+	rows, err := db.pool.Query(ctx, `
+		SELECT id, site_id, name, pms_config, pbx_config, settings, enabled, created_at, updated_at
+		FROM tenants WHERE site_id = $1 ORDER BY name
+	`, siteID)
+	if err != nil {
+		return nil, fmt.Errorf("querying tenants by site: %w", err)
+	}
+	defer rows.Close()
+
+	var tenants []Tenant
+	for rows.Next() {
+		var t Tenant
+		if err := rows.Scan(&t.ID, &t.SiteID, &t.Name, &t.PMSConfig, &t.PBXConfig, &t.Settings, &t.Enabled, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scanning tenant: %w", err)
+		}
+		tenants = append(tenants, t)
+	}
+	return tenants, nil
+}
+
+// =============================================================================
 // Tenant Repository
 // =============================================================================
 
 // Tenant represents a row in the tenants table
 type Tenant struct {
 	ID        string
+	SiteID    *string // Pointer to allow NULL when no site assigned
 	Name      string
 	PMSConfig map[string]interface{}
 	PBXConfig map[string]interface{}
@@ -93,9 +219,9 @@ type Tenant struct {
 func (db *DB) GetTenant(ctx context.Context, id string) (*Tenant, error) {
 	var t Tenant
 	err := db.pool.QueryRow(ctx, `
-		SELECT id, name, pms_config, pbx_config, settings, enabled, created_at, updated_at
+		SELECT id, site_id, name, pms_config, pbx_config, settings, enabled, created_at, updated_at
 		FROM tenants WHERE id = $1
-	`, id).Scan(&t.ID, &t.Name, &t.PMSConfig, &t.PBXConfig, &t.Settings, &t.Enabled, &t.CreatedAt, &t.UpdatedAt)
+	`, id).Scan(&t.ID, &t.SiteID, &t.Name, &t.PMSConfig, &t.PBXConfig, &t.Settings, &t.Enabled, &t.CreatedAt, &t.UpdatedAt)
 
 	if err == pgx.ErrNoRows {
 		return nil, nil
@@ -109,7 +235,7 @@ func (db *DB) GetTenant(ctx context.Context, id string) (*Tenant, error) {
 // ListTenants returns all tenants
 func (db *DB) ListTenants(ctx context.Context) ([]Tenant, error) {
 	rows, err := db.pool.Query(ctx, `
-		SELECT id, name, pms_config, pbx_config, settings, enabled, created_at, updated_at
+		SELECT id, site_id, name, pms_config, pbx_config, settings, enabled, created_at, updated_at
 		FROM tenants ORDER BY name
 	`)
 	if err != nil {
@@ -120,7 +246,7 @@ func (db *DB) ListTenants(ctx context.Context) ([]Tenant, error) {
 	var tenants []Tenant
 	for rows.Next() {
 		var t Tenant
-		if err := rows.Scan(&t.ID, &t.Name, &t.PMSConfig, &t.PBXConfig, &t.Settings, &t.Enabled, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		if err := rows.Scan(&t.ID, &t.SiteID, &t.Name, &t.PMSConfig, &t.PBXConfig, &t.Settings, &t.Enabled, &t.CreatedAt, &t.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scanning tenant: %w", err)
 		}
 		tenants = append(tenants, t)
@@ -131,9 +257,9 @@ func (db *DB) ListTenants(ctx context.Context) ([]Tenant, error) {
 // CreateTenant creates a new tenant
 func (db *DB) CreateTenant(ctx context.Context, t *Tenant) error {
 	_, err := db.pool.Exec(ctx, `
-		INSERT INTO tenants (id, name, pms_config, pbx_config, settings, enabled)
-		VALUES ($1, $2, $3, $4, $5, $6)
-	`, t.ID, t.Name, t.PMSConfig, t.PBXConfig, t.Settings, t.Enabled)
+		INSERT INTO tenants (id, site_id, name, pms_config, pbx_config, settings, enabled)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, t.ID, t.SiteID, t.Name, t.PMSConfig, t.PBXConfig, t.Settings, t.Enabled)
 	if err != nil {
 		return fmt.Errorf("creating tenant: %w", err)
 	}
@@ -144,9 +270,9 @@ func (db *DB) CreateTenant(ctx context.Context, t *Tenant) error {
 func (db *DB) UpdateTenant(ctx context.Context, t *Tenant) error {
 	_, err := db.pool.Exec(ctx, `
 		UPDATE tenants
-		SET name = $2, pms_config = $3, pbx_config = $4, settings = $5, enabled = $6, updated_at = NOW()
+		SET site_id = $2, name = $3, pms_config = $4, pbx_config = $5, settings = $6, enabled = $7, updated_at = NOW()
 		WHERE id = $1
-	`, t.ID, t.Name, t.PMSConfig, t.PBXConfig, t.Settings, t.Enabled)
+	`, t.ID, t.SiteID, t.Name, t.PMSConfig, t.PBXConfig, t.Settings, t.Enabled)
 	if err != nil {
 		return fmt.Errorf("updating tenant: %w", err)
 	}

--- a/internal/tenant/manager.go
+++ b/internal/tenant/manager.go
@@ -79,13 +79,70 @@ func (m *Manager) LoadFromDB(ctx context.Context) error {
 
 // dbTenantToConfig converts a database tenant row to a TenantConfig
 func (m *Manager) dbTenantToConfig(t db.Tenant) config.TenantConfig {
-	return config.TenantConfig{
+	tc := config.TenantConfig{
 		ID:     t.ID,
 		Name:   t.Name,
+		SiteID: pointerString(t.SiteID),
 		PMS:    pmsConfigFromMap(t.PMSConfig),
 		PBX:    pbxConfigFromMap(t.PBXConfig),
-		Settings: t.Settings,
 	}
+	// Convert generic map to TenantSettings if possible
+	if settingsMap, ok := t.Settings["features"].(map[string]interface{}); ok {
+		if wakeUp, ok := settingsMap["wake_up_calls"].(bool); ok {
+			tc.Settings.Features.WakeUpCalls = wakeUp
+		}
+		if roomClean, ok := settingsMap["room_clean_code"].(bool); ok {
+			tc.Settings.Features.RoomCleanCode = roomClean
+		}
+		if dnd, ok := settingsMap["dnd"].(bool); ok {
+			tc.Settings.Features.DND = dnd
+		}
+		if mwi, ok := settingsMap["mwi"].(bool); ok {
+			tc.Settings.Features.MWI = mwi
+		}
+		if voicemail, ok := settingsMap["voicemail"].(bool); ok {
+			tc.Settings.Features.Voicemail = voicemail
+		}
+		if callForward, ok := settingsMap["call_forward"].(bool); ok {
+			tc.Settings.Features.CallForward = callForward
+		}
+	}
+	if accessCodes, ok := t.Settings["access_codes"].(map[string]interface{}); ok {
+		if code, ok := accessCodes["wake_up"].(string); ok {
+			tc.Settings.AccessCodes.WakeUp = code
+		}
+		if code, ok := accessCodes["room_clean"].(string); ok {
+			tc.Settings.AccessCodes.RoomClean = code
+		}
+		if code, ok := accessCodes["room_service"].(string); ok {
+			tc.Settings.AccessCodes.RoomService = code
+		}
+		if code, ok := accessCodes["do_not_disturb"].(string); ok {
+			tc.Settings.AccessCodes.DoNotDisturb = code
+		}
+		if code, ok := accessCodes["voicemail"].(string); ok {
+			tc.Settings.AccessCodes.Voicemail = code
+		}
+	}
+	if roomPrefix, ok := t.Settings["room_prefix"].(string); ok {
+		tc.Settings.RoomPrefix = roomPrefix
+	}
+	if extRange, ok := t.Settings["extension_range"].([]interface{}); ok && len(extRange) == 2 {
+		if min, ok := extRange[0].(float64); ok {
+			tc.Settings.ExtensionRange[0] = int(min)
+		}
+		if max, ok := extRange[1].(float64); ok {
+			tc.Settings.ExtensionRange[1] = int(max)
+		}
+	}
+	return tc
+}
+
+func pointerString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // pmsConfigFromMap converts a map to PMSConfig

--- a/migrations/002_sites.sql
+++ b/migrations/002_sites.sql
@@ -1,0 +1,21 @@
+-- Add sites table for grouping tenants by physical location
+CREATE TABLE sites (
+    id          VARCHAR(64) PRIMARY KEY,
+    name        VARCHAR(255) NOT NULL,
+    auth_code   VARCHAR(128) NOT NULL,  -- Secret for site connector authentication
+    settings    JSONB DEFAULT '{}',
+    enabled     BOOLEAN DEFAULT TRUE,
+    created_at  TIMESTAMPTZ DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Add site_id foreign key to tenants table
+ALTER TABLE tenants ADD COLUMN site_id VARCHAR(64) REFERENCES sites(id) ON DELETE SET NULL;
+
+-- Create index for site lookups
+CREATE INDEX idx_tenants_site ON tenants(site_id);
+
+-- Trigger for sites updated_at
+CREATE TRIGGER update_sites_updated_at
+    BEFORE UPDATE ON sites
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary

This PR adds core infrastructure for multi-tenant Bicom ARI management:

### Features Added

1. **Sites Management**
   - `sites` table with auth_code for site connector authentication
   - `site_id` foreign key on tenants table
   - Site repository methods (CRUD + auth validation)

2. **Tenant Settings Configuration**
   - `TenantSettings` struct with feature flags (wake_up_calls, room_clean_code, DND, MWI, etc.)
   - `AccessCodes` for feature codes (wake_up, room_clean, room_service, etc.)
   - Extension range [min/max] for validation

3. **Admin API for Sites**
   - Full CRUD at `/admin/sites` endpoints
   - Site ID validation, auth code requirements (min 16 chars)

4. **ARI Event Debugging**
   - `ARIEvent` struct for capturing events
   - `EventObserver` interface for receiving events
   - `EventFilter` for selective event capture
   - `GetRecentEvents()` with circular buffer (1000 events max)
   - `EnableDebugging()` / `DisableDebugging()` methods

### Files Changed

- `internal/api/admin_sites.go` (new)
- `internal/api/admin_tenants.go` (updated)
- `internal/api/api.go` (routes)
- `internal/ari/client.go` (debugging)
- `internal/config/config.go` (tenant settings)
- `internal/db/db.go` (site repository)
- `internal/tenant/manager.go` (site handling)
- `migrations/002_sites.sql` (new)

Closes TOP-59, TOP-60, TOP-61